### PR TITLE
chore: fix msrv check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
   merge_group:
 
 env:
-  RUST_MIN: 1.63
+  RUST_MIN: "1.70"
 
 jobs:
   test:
@@ -76,6 +76,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      # this interferes with the rust version that gets used
+      - name: remove toolchain
+        run: rm rust-toolchain.toml
       - name: Install Rust ${{ env.RUST_MIN }}
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/README.md
+++ b/README.md
@@ -199,4 +199,4 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
 ## Supported Rust Versions
 
-The MSRV is currently `1.63.0`.
+The MSRV is currently `1.70.0`.


### PR DESCRIPTION
The MSRV was incorrectly reported as 1.63 because the `rust-toolchain.toml` file was overriding the version that the check ran against.