### PR TITLE
refactor: reader and writer creation now one method

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,3 +22,7 @@ We use some nightly-only features with rustfmt. If you're using rust analyzer, y
 See [here](https://github.com/rust-lang/rust-analyzer/issues/3627).
 If you're using the command line, you can run `cargo +nightly fmt`.
 If you install the git hooks, these are checked before commit.
+
+## Required Dev Packages
+
+Tests have a transient dependency on the `alsa-sys` crate. That crate needs the `libasound2-dev` package installed on Debian based systems.

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -1,8 +1,8 @@
-//! An HTTP implementation of the [SourceStream] trait.
+//! An HTTP implementation of the [`SourceStream`] trait.
 //!
 //! An implementation of the [Client] trait using [reqwest](https://docs.rs/reqwest/latest/reqwest)
 //! is provided if the `request` feature is enabled. If you need to customize the client object, you
-//! can use [HttpStream::new](crate::http::HttpStream::new) to supply your own reqwest client. Keep
+//! can use [`HttpStream::new`](crate::http::HttpStream::new) to supply your own reqwest client. Keep
 //! in mind that reqwest recommends creating a single client and cloning it for each new connection.
 //!
 //! # Example
@@ -129,7 +129,7 @@ pub trait ClientResponse: Send + Sync {
     fn stream(self) -> Box<dyn Stream<Item = Result<Bytes, Self::Error>> + Unpin + Send + Sync>;
 }
 
-/// An HTTP implementation of the [SourceStream] trait.
+/// An HTTP implementation of the [`SourceStream`] trait.
 pub struct HttpStream<C: Client> {
     stream: Box<dyn Stream<Item = Result<Bytes, C::Error>> + Unpin + Send + Sync>,
     client: C,
@@ -192,7 +192,7 @@ impl<C: Client> HttpStream<C> {
         })
     }
 
-    /// The [ContentType] of the response stream.
+    /// The [`ContentType`] of the response stream.
     pub fn content_type(&self) -> &Option<ContentType> {
         &self.content_type
     }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -2,8 +2,9 @@
 //!
 //! An implementation of the [Client] trait using [reqwest](https://docs.rs/reqwest/latest/reqwest)
 //! is provided if the `request` feature is enabled. If you need to customize the client object, you
-//! can use [`HttpStream::new`](crate::http::HttpStream::new) to supply your own reqwest client. Keep
-//! in mind that reqwest recommends creating a single client and cloning it for each new connection.
+//! can use [`HttpStream::new`](crate::http::HttpStream::new) to supply your own reqwest client.
+//! Keep in mind that reqwest recommends creating a single client and cloning it for each new
+//! connection.
 //!
 //! # Example
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,8 +201,8 @@ impl<P: StorageProvider> StreamDownload<P> {
     {
         let stream = make_stream().await.wrap_err("error creating stream")?;
         let content_length = stream.content_length();
-        let storage = storage_provider.create_reader(content_length)?;
-        let source = Source::new(storage_provider.writer()?, content_length, settings);
+        let (reader, writer) = storage_provider.into_reader_writer(content_length)?;
+        let source = Source::new(writer, content_length, settings);
         let handle = source.source_handle();
         let cancellation_token = CancellationToken::new();
         let cancellation_token_ = cancellation_token.clone();
@@ -217,7 +217,7 @@ impl<P: StorageProvider> StreamDownload<P> {
         });
 
         Ok(Self {
-            output_reader: storage,
+            output_reader: reader,
             handle,
             download_task_cancellation_token: cancellation_token,
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ pub struct StreamDownload<P: StorageProvider> {
 
 impl<P: StorageProvider> StreamDownload<P> {
     #[cfg(feature = "reqwest")]
-    /// Creates a new [StreamDownload] that accesses an HTTP resource at the given URL.
+    /// Creates a new [`StreamDownload`] that accesses an HTTP resource at the given URL.
     ///
     /// # Example
     ///
@@ -103,7 +103,7 @@ impl<P: StorageProvider> StreamDownload<P> {
         Self::new::<http::HttpStream<::reqwest::Client>>(url, storage_provider, settings).await
     }
 
-    /// Creates a new [StreamDownload] that accesses a remote resource at the given URL.
+    /// Creates a new [`StreamDownload`] that accesses a remote resource at the given URL.
     ///
     /// # Example
     ///
@@ -139,7 +139,7 @@ impl<P: StorageProvider> StreamDownload<P> {
         Self::from_make_stream(move || S::create(url), storage_provider, settings).await
     }
 
-    /// Creates a new [StreamDownload] from a [SourceStream].
+    /// Creates a new [`StreamDownload`] from a [`SourceStream`].
     ///
     /// # Example
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ use std::future::{self, Future};
 use std::io::{self, Read, Seek, SeekFrom};
 
 use source::{Source, SourceHandle, SourceStream};
-use storage::{StorageProvider, StorageReader};
+use storage::StorageProvider;
 use tap::{Tap, TapFallible};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, instrument, trace};
@@ -202,7 +202,7 @@ impl<P: StorageProvider> StreamDownload<P> {
         let stream = make_stream().await.wrap_err("error creating stream")?;
         let content_length = stream.content_length();
         let storage = storage_provider.create_reader(content_length)?;
-        let source = Source::new(storage.writer()?, content_length, settings);
+        let source = Source::new(storage_provider.writer()?, content_length, settings);
         let handle = source.source_handle();
         let cancellation_token = CancellationToken::new();
         let cancellation_token_ = cancellation_token.clone();

--- a/src/source.rs
+++ b/src/source.rs
@@ -1,4 +1,4 @@
-//! Provides the [SourceStream] trait which abstracts over the transport used to
+//! Provides the [`SourceStream`] trait which abstracts over the transport used to
 //! stream remote content.
 use std::error::Error;
 use std::io::{self, SeekFrom};

--- a/src/storage/adaptive.rs
+++ b/src/storage/adaptive.rs
@@ -94,8 +94,6 @@ where
     }
 }
 
-impl<T> StorageReader for AdaptiveStorageReader<T> where T: StorageReader {}
-
 /// Write handle created by an [AdaptiveStorageReader].
 #[derive(Debug)]
 pub enum AdaptiveStorageWriter<T: StorageWriter> {

--- a/src/storage/adaptive.rs
+++ b/src/storage/adaptive.rs
@@ -11,7 +11,7 @@ use std::num::NonZeroUsize;
 use super::bounded::{BoundedStorageProvider, BoundedStorageReader, BoundedStorageWriter};
 use super::{StorageProvider, StorageReader, StorageWriter};
 
-/// Creates an [AdaptiveStorageReader] based in the supplied content length
+/// Creates an [`AdaptiveStorageReader`] based in the supplied content length
 #[derive(Clone, Debug)]
 pub struct AdaptiveStorageProvider<T>
 where
@@ -25,8 +25,8 @@ impl<T> AdaptiveStorageProvider<T>
 where
     T: StorageProvider,
 {
-    /// Creates a new [AdaptiveStorageProvider]. The supplied size is used to construct a
-    /// [BoundedStorageReader] when the stream doesn't have a known content length.
+    /// Creates a new [`AdaptiveStorageProvider`]. The supplied size is used to construct a
+    /// [`BoundedStorageReader`] when the stream doesn't have a known content length.
     pub fn new(inner: T, size: NonZeroUsize) -> Self {
         Self {
             inner,
@@ -35,7 +35,7 @@ where
     }
 }
 
-/// Reader created by an [AdaptiveStorageProvider].
+/// Reader created by an [`AdaptiveStorageProvider`].
 #[derive(Debug)]
 pub enum AdaptiveStorageReader<T: StorageReader> {
     /// Bounded reader used for infinite streams.
@@ -94,7 +94,7 @@ where
     }
 }
 
-/// Write handle created by an [AdaptiveStorageReader].
+/// Write handle created by an [`AdaptiveStorageReader`].
 #[derive(Debug)]
 pub enum AdaptiveStorageWriter<T: StorageWriter> {
     /// Bounded reader used for infinite streams.

--- a/src/storage/adaptive.rs
+++ b/src/storage/adaptive.rs
@@ -28,10 +28,7 @@ where
     /// Creates a new [`AdaptiveStorageProvider`]. The supplied size is used to construct a
     /// [`BoundedStorageReader`] when the stream doesn't have a known content length.
     pub fn new(inner: T, size: NonZeroUsize) -> Self {
-        Self {
-            inner,
-            size,
-        }
+        Self { inner, size }
     }
 }
 

--- a/src/storage/bounded.rs
+++ b/src/storage/bounded.rs
@@ -19,7 +19,7 @@ use tracing::{debug, instrument, trace, warn};
 use super::{StorageProvider, StorageReader, StorageWriter};
 use crate::WrapIoResult;
 
-/// Creates a [BoundedStorageReader] with a fixed size.
+/// Creates a [`BoundedStorageReader`] with a fixed size.
 #[derive(Clone, Debug)]
 pub struct BoundedStorageProvider<T>
 where
@@ -33,7 +33,7 @@ impl<T> BoundedStorageProvider<T>
 where
     T: StorageProvider,
 {
-    /// Creates a new [BoundedStorageProvider] with the specified fixed buffer size.
+    /// Creates a new [`BoundedStorageProvider`] with the specified fixed buffer size.
     pub fn new(inner: T, size: NonZeroUsize) -> Self {
         Self {
             inner,
@@ -93,7 +93,7 @@ impl SharedInfo {
     }
 }
 
-/// Reader created by a [BoundedStorageProvider]. Reads from a fixed-size circular buffer.
+/// Reader created by a [`BoundedStorageProvider`]. Reads from a fixed-size circular buffer.
 pub struct BoundedStorageReader<T>
 where
     T: StorageReader,
@@ -214,7 +214,7 @@ where
     }
 }
 
-/// Write handle created by a [BoundedStorageReader]. Writes to a fixed-size circular buffer.
+/// Write handle created by a [`BoundedStorageReader`]. Writes to a fixed-size circular buffer.
 pub struct BoundedStorageWriter<T>
 where
     T: StorageWriter,

--- a/src/storage/bounded.rs
+++ b/src/storage/bounded.rs
@@ -113,8 +113,6 @@ where
     }
 }
 
-impl<T> StorageReader for BoundedStorageReader<T> where T: StorageReader {}
-
 impl<T> Read for BoundedStorageReader<T>
 where
     T: StorageReader,

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use parking_lot::RwLock;
 
-use super::{StorageProvider, StorageReader};
+use super::StorageProvider;
 
 /// Creates a [MemoryStorage] with an initial size based on the supplied content length.
 #[derive(Default, Clone, Debug)]
@@ -44,8 +44,6 @@ pub struct MemoryStorage {
     pos: usize,
     written: Arc<AtomicUsize>,
 }
-
-impl StorageReader for MemoryStorage {}
 
 impl Read for MemoryStorage {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -9,7 +9,7 @@ use parking_lot::RwLock;
 
 use super::StorageProvider;
 
-/// Creates a [MemoryStorage] with an initial size based on the supplied content length.
+/// Creates a [`MemoryStorage`] with an initial size based on the supplied content length.
 #[derive(Default, Clone, Debug)]
 pub struct MemoryStorageProvider;
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -18,15 +18,11 @@ pub trait StorageProvider: Clone + Send {
     /// Handle that can write to the underlying storage.
     type Writer: StorageWriter;
 
-    /// Builds the reader with the specified content length.
-    fn create_reader(&self, content_length: Option<u64>) -> io::Result<Self::Reader>;
-
-    /// Returns a handle that can write to the underlying storage.
-    fn writer(&self) -> io::Result<Self::Writer>;
-
-    // Turn the provider into a reader and writer.
-    // TODO provide two methods instead of having this argument
-//     fn into_reader_writer(self, content_length: Option<u64>) -> io::Result<(Self::Reader, Self::Writer)>;
+    /// Turn the provider into a reader and writer.
+    fn into_reader_writer(
+        self,
+        content_length: Option<u64>,
+    ) -> io::Result<(Self::Reader, Self::Writer)>;
 }
 
 /// Trait used to read from a storage layer

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -9,23 +9,28 @@ pub mod memory;
 pub mod temp;
 
 /// Creates a [StorageReader] based on the content length returned from the
-/// [SourceStream](crate::source::SourceStream).
+/// [SourceStream](crate::source::SourceStream).And construct a writable handle.
+/// The reader and writer must track their position in the stream independently.
+
 pub trait StorageProvider: Clone + Send {
     /// Source used to read from the underlying storage.
     type Reader: StorageReader;
-    /// Builds the reader with the specified content length.
-    fn create_reader(&self, content_length: Option<u64>) -> io::Result<Self::Reader>;
-}
-
-/// Trait used to read from a storage layer and construct a writable handle.
-/// The reader and writer must track their position in the stream independently.
-pub trait StorageReader: Read + Seek + Send {
     /// Handle that can write to the underlying storage.
     type Writer: StorageWriter;
 
+    /// Builds the reader with the specified content length.
+    fn create_reader(&self, content_length: Option<u64>) -> io::Result<Self::Reader>;
+
     /// Returns a handle that can write to the underlying storage.
     fn writer(&self) -> io::Result<Self::Writer>;
+
+    // Turn the provider into a reader and writer.
+    // TODO provide two methods instead of having this argument
+//     fn into_reader_writer(self, content_length: Option<u64>) -> io::Result<(Self::Reader, Self::Writer)>;
 }
+
+/// Trait used to read from a storage layer
+pub trait StorageReader: Read + Seek + Send {}
 
 /// Handle for writing to the underlying storage layer.
 pub trait StorageWriter: Write + Seek + Send + 'static {}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -8,10 +8,9 @@ pub mod memory;
 #[cfg(feature = "temp-storage")]
 pub mod temp;
 
-/// Creates a [StorageReader] based on the content length returned from the
-/// [SourceStream](crate::source::SourceStream).And construct a writable handle.
+/// Creates a [`StorageReader`] and [`StorageWriter`] based on the content 
+/// length returned from the [`SourceStream`](crate::source::SourceStream). 
 /// The reader and writer must track their position in the stream independently.
-
 pub trait StorageProvider: Clone + Send {
     /// Source used to read from the underlying storage.
     type Reader: StorageReader;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -8,8 +8,8 @@ pub mod memory;
 #[cfg(feature = "temp-storage")]
 pub mod temp;
 
-/// Creates a [`StorageReader`] and [`StorageWriter`] based on the content 
-/// length returned from the [`SourceStream`](crate::source::SourceStream). 
+/// Creates a [`StorageReader`] and [`StorageWriter`] based on the content
+/// length returned from the [`SourceStream`](crate::source::SourceStream).
 /// The reader and writer must track their position in the stream independently.
 pub trait StorageProvider: Clone + Send {
     /// Source used to read from the underlying storage.

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -28,6 +28,8 @@ pub trait StorageProvider: Clone + Send {
 /// Trait used to read from a storage layer
 pub trait StorageReader: Read + Seek + Send {}
 
+impl<T> StorageReader for T where T: Read + Seek + Send {}
+
 /// Handle for writing to the underlying storage layer.
 pub trait StorageWriter: Write + Seek + Send + 'static {}
 

--- a/src/storage/temp.rs
+++ b/src/storage/temp.rs
@@ -17,15 +17,14 @@ pub struct TempStorageProvider {
 }
 
 impl TempStorageProvider {
-    /// Creates a new [`TempStorageProvider`] that creates temporary files in the OS-specific default
-    /// location.
+    /// Creates a new [`TempStorageProvider`] that creates temporary files in the OS-specific
+    /// default location.
     pub fn new() -> Self {
-        Self {
-            storage_dir: None,
-        }
+        Self { storage_dir: None }
     }
 
-    /// Creates a new [`TempStorageProvider`] that creates temporary files in the specified location.
+    /// Creates a new [`TempStorageProvider`] that creates temporary files in the specified
+    /// location.
     pub fn new_in(path: impl Into<PathBuf>) -> Self {
         Self {
             storage_dir: Some(path.into()),

--- a/src/storage/temp.rs
+++ b/src/storage/temp.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 
 use tempfile::NamedTempFile;
 
-use super::{StorageProvider, StorageReader};
+use super::StorageProvider;
 use crate::WrapIoResult;
 
 /// Creates a [TempStorageReader] backed by a temporary file
@@ -76,5 +76,3 @@ impl Seek for TempStorageReader {
         self.reader.seek(pos)
     }
 }
-
-impl StorageReader for TempStorageReader {}

--- a/src/storage/temp.rs
+++ b/src/storage/temp.rs
@@ -10,14 +10,14 @@ use tempfile::NamedTempFile;
 use super::StorageProvider;
 use crate::WrapIoResult;
 
-/// Creates a [TempStorageReader] backed by a temporary file
+/// Creates a [`TempStorageReader`] backed by a temporary file
 #[derive(Default, Clone, Debug)]
 pub struct TempStorageProvider {
     storage_dir: Option<PathBuf>,
 }
 
 impl TempStorageProvider {
-    /// Creates a new [TempStorageProvider] that creates temporary files in the OS-specific default
+    /// Creates a new [`TempStorageProvider`] that creates temporary files in the OS-specific default
     /// location.
     pub fn new() -> Self {
         Self {
@@ -25,7 +25,7 @@ impl TempStorageProvider {
         }
     }
 
-    /// Creates a new [TempStorageProvider] that creates temporary files in the specified location.
+    /// Creates a new [`TempStorageProvider`] that creates temporary files in the specified location.
     pub fn new_in(path: impl Into<PathBuf>) -> Self {
         Self {
             storage_dir: Some(path.into()),
@@ -59,7 +59,7 @@ impl StorageProvider for TempStorageProvider {
     }
 }
 
-/// Reader created by a [TempStorageProvider]. Reads from a temporary file.
+/// Reader created by a [`TempStorageProvider`]. Reads from a temporary file.
 #[derive(Debug)]
 pub struct TempStorageReader {
     reader: BufReader<NamedTempFile>,


### PR DESCRIPTION
Thanks for creating this lib! For my podcast app I also want to support downloading to a permanent file. Before I implement that I went about and refactored the storage module a bit. Mostly as an exercise to familiarize myself with your code base. I think the results are worth contributing I hope they are welcome and you agree with the refactoring.

This is the phase of a two phase refactor moving writer creation to the
StorageProvide. This has two advantages:

 - the new method takes self as argument therefore it is no longer possible to get multiple writers.
 - shared data between reader and writer is created and distributed at
       the same place (instead of the writers share going through the
       reader)
