### PR TITLE
refactor(download) + feat(permanent storage)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ reqwest = { version = "0.11.10", features = [
 ], default-features = false, optional = true }
 tap = "1.0.1"
 tempfile = { version = "3", optional = true }
+thiserror = "1"
 tokio = { version = "1.23.1", features = ["sync", "macros", "rt"] }
 tokio-util = "0.7.1"
 tracing = "0.1.36"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,7 +241,7 @@ impl<P: StorageProvider> Read for StreamDownload<P> {
             requested_position = requested_position
         );
 
-        if let Some(closest_set) = self.handle.downloaded().get(&stream_position) {
+        if let Some(closest_set) = self.handle.get_downloaded_around(stream_position) {
             trace!(
                 downloaded_range = format!("{closest_set:?}"),
                 "current position already downloaded"
@@ -316,7 +316,7 @@ impl<P: StorageProvider> Seek for StreamDownload<P> {
             self.handle.content_length(),
             self.output_reader.stream_position()?,
         )?;
-        if let Some(closest_set) = self.handle.downloaded().get(&absolute_seek_pos) {
+        if let Some(closest_set) = self.handle.get_downloaded_around(absolute_seek_pos) {
             debug!(
                 downloaded_range = format!("{closest_set:?}"),
                 "seek position already downloaded"

--- a/src/source.rs
+++ b/src/source.rs
@@ -124,12 +124,21 @@ pub(crate) struct Source<W: StorageWriter> {
     settings: Settings,
 }
 
+fn init_downloaded<H: StorageWriter>(writer: &H) -> Arc<RwLock<RangeSet<u64>>> {
+    if let Some(downloaded) = writer.downloaded() {
+        Arc::new(RwLock::new(downloaded))
+    } else {
+        Default::default()
+    }
+}
+
 impl<H: StorageWriter> Source<H> {
     pub(crate) fn new(writer: H, content_length: Option<u64>, settings: Settings) -> Self {
         let (seek_tx, seek_rx) = mpsc::channel(32);
+        let downloaded = init_downloaded(&writer);
         Self {
             writer,
-            downloaded: Default::default(),
+            downloaded,
             requested_position: Arc::new(AtomicI64::new(-1)),
             position_reached: Default::default(),
             seek_tx,

--- a/src/source.rs
+++ b/src/source.rs
@@ -95,7 +95,7 @@ impl Default for RequestedPosition {
 }
 
 // relaxed ordering as we are not using the atomic to
-// lock something or to syncronize threads.
+// lock something or to synchronize threads.
 impl RequestedPosition {
     fn clear(&self) {
         self.0.store(-1, Ordering::Relaxed);

--- a/src/source.rs
+++ b/src/source.rs
@@ -103,11 +103,7 @@ impl RequestedPosition {
 
     fn get(&self) -> Option<u64> {
         let val = self.0.load(Ordering::Relaxed);
-        if val == -1 {
-            None
-        } else {
-            Some(val as u64)
-        }
+        if val == -1 { None } else { Some(val as u64) }
     }
 
     fn set(&self, position: u64) {

--- a/src/source.rs
+++ b/src/source.rs
@@ -162,7 +162,7 @@ impl Downloaded {
         self.0.read().get(&pos).cloned()
     }
     fn next_gap(&self, range: &Range<u64>) -> Option<Range<u64>> {
-        self.0.read().gaps(&range).next()
+        self.0.read().gaps(range).next()
     }
 }
 
@@ -179,7 +179,6 @@ pub(crate) struct Source<W: StorageWriter> {
 
 struct Download {
     prefetch_complete: bool,
-    download_all: bool,
     status: Option<DownloadStatus>,
 }
 
@@ -192,7 +191,6 @@ impl Download {
     fn new(settings: &Settings) -> Self {
         Self {
             prefetch_complete: settings.prefetch_bytes == 0,
-            download_all: false,
             status: None,
         }
     }
@@ -247,9 +245,9 @@ impl<H: StorageWriter> Source<H> {
             };
 
             use DownloadStatus as DS;
-            match download.status.as_ref().unwrap() {
-                DS::Continue => continue,
-                DS::Complete => break,
+            match download.status.as_ref() {
+                None | Some(DS::Continue) => continue,
+                Some(DS::Complete) => break,
             }
         }
         Ok(())

--- a/src/source.rs
+++ b/src/source.rs
@@ -124,18 +124,11 @@ pub(crate) struct Source<W: StorageWriter> {
     settings: Settings,
 }
 
-fn init_downloaded<H: StorageWriter>(writer: &H) -> Arc<RwLock<RangeSet<u64>>> {
-    if let Some(downloaded) = writer.downloaded() {
-        Arc::new(RwLock::new(downloaded))
-    } else {
-        Default::default()
-    }
-}
-
 impl<H: StorageWriter> Source<H> {
     pub(crate) fn new(writer: H, content_length: Option<u64>, settings: Settings) -> Self {
         let (seek_tx, seek_rx) = mpsc::channel(32);
-        let downloaded = init_downloaded(&writer);
+        let downloaded = Arc::new(RwLock::new(writer.downloaded()));
+
         Self {
             writer,
             downloaded,

--- a/src/storage/adaptive.rs
+++ b/src/storage/adaptive.rs
@@ -130,3 +130,5 @@ where
         }
     }
 }
+
+impl<T: Send + Read + Seek +'static> StorageWriter for AdaptiveStorageWriter<T>;

--- a/src/storage/adaptive.rs
+++ b/src/storage/adaptive.rs
@@ -131,4 +131,4 @@ where
     }
 }
 
-impl<T: Send + Read + Seek +'static> StorageWriter for AdaptiveStorageWriter<T>;
+impl<T: StorageWriter +'static> StorageWriter for AdaptiveStorageWriter<T> {}

--- a/src/storage/adaptive.rs
+++ b/src/storage/adaptive.rs
@@ -131,4 +131,4 @@ where
     }
 }
 
-impl<T: StorageWriter +'static> StorageWriter for AdaptiveStorageWriter<T> {}
+impl<T: StorageWriter + 'static> StorageWriter for AdaptiveStorageWriter<T> {}

--- a/src/storage/bounded.rs
+++ b/src/storage/bounded.rs
@@ -303,4 +303,4 @@ where
     }
 }
 
-impl<T: StorageWriter +'static> StorageWriter for BoundedStorageWriter<T> {}
+impl<T: StorageWriter + 'static> StorageWriter for BoundedStorageWriter<T> {}

--- a/src/storage/bounded.rs
+++ b/src/storage/bounded.rs
@@ -302,3 +302,5 @@ where
         Ok(new_pos as u64)
     }
 }
+
+impl<T: StorageWriter +'static> StorageWriter for BoundedStorageWriter<T> {}

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use parking_lot::RwLock;
 
-use super::StorageProvider;
+use super::{StorageProvider, StorageWriter};
 
 /// Creates a [`MemoryStorage`] with an initial size based on the supplied content length.
 #[derive(Default, Clone, Debug)]
@@ -90,3 +90,5 @@ impl Write for MemoryStorage {
         Ok(())
     }
 }
+
+impl StorageWriter for MemoryStorage {}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -37,7 +37,7 @@ impl<T> StorageReader for T where T: Read + Seek + Send {}
 pub trait StorageWriter: Write + Seek + Send + 'static {
     /// If the underlying storage can resume a download return progress
     /// already made 
-    fn downloaded(&self) -> Option<RangeSet<u64>> {
-        None
+    fn downloaded(&self) -> RangeSet<u64> {
+        RangeSet::new()
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -9,7 +9,7 @@ pub mod bounded;
 pub mod memory;
 #[cfg(feature = "temp-storage")]
 pub mod temp;
-// #[cfg(feature = "unstable-permanent-storage")]
+#[cfg(feature = "unstable-permanent-storage")]
 pub mod permanent;
 
 /// Creates a [`StorageReader`] and [`StorageWriter`] based on the content

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -36,7 +36,7 @@ impl<T> StorageReader for T where T: Read + Seek + Send {}
 /// Handle for writing to the underlying storage layer.
 pub trait StorageWriter: Write + Seek + Send + 'static {
     /// If the underlying storage can resume a download return progress
-    /// already made 
+    /// already made
     fn downloaded(&self) -> RangeSet<u64> {
         RangeSet::new()
     }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -2,11 +2,15 @@
 //! Pre-configured implementations are available for memory and temporary file-based storage.
 use std::io::{self, Read, Seek, Write};
 
+use rangemap::RangeSet;
+
 pub mod adaptive;
 pub mod bounded;
 pub mod memory;
 #[cfg(feature = "temp-storage")]
 pub mod temp;
+// #[cfg(feature = "unstable-permanent-storage")]
+pub mod permanent;
 
 /// Creates a [`StorageReader`] and [`StorageWriter`] based on the content
 /// length returned from the [`SourceStream`](crate::source::SourceStream).
@@ -30,6 +34,10 @@ pub trait StorageReader: Read + Seek + Send {}
 impl<T> StorageReader for T where T: Read + Seek + Send {}
 
 /// Handle for writing to the underlying storage layer.
-pub trait StorageWriter: Write + Seek + Send + 'static {}
-
-impl<T> StorageWriter for T where T: Write + Seek + Send + 'static {}
+pub trait StorageWriter: Write + Seek + Send + 'static {
+    /// If the underlying storage can resume a download return progress
+    /// already made 
+    fn downloaded(&self) -> Option<RangeSet<u64>> {
+        None
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -7,10 +7,10 @@ use rangemap::RangeSet;
 pub mod adaptive;
 pub mod bounded;
 pub mod memory;
-#[cfg(feature = "temp-storage")]
-pub mod temp;
 #[cfg(feature = "unstable-permanent-storage")]
 pub mod permanent;
+#[cfg(feature = "temp-storage")]
+pub mod temp;
 
 /// Creates a [`StorageReader`] and [`StorageWriter`] based on the content
 /// length returned from the [`SourceStream`](crate::source::SourceStream).

--- a/src/storage/permanent.rs
+++ b/src/storage/permanent.rs
@@ -1,0 +1,146 @@
+//! Storage implementations for reading and writing to a user specified permanent file. Seeking is
+//! still supported, when all data in front of the current seekpoint has been downloaded any
+//! missing parts in front are downloaded. To keep track of the downloaded data every
+//! [`PermanentStorageProvider`] creates a .progress file.
+use std::ffi::OsStr;
+use std::fs::File;
+use std::io::{BufReader, BufWriter, Read, Seek, Write};
+use std::path::PathBuf;
+use std::{fs, io};
+
+use crate::StorageProvider;
+
+mod progress;
+use progress::Progress;
+
+use super::StorageWriter;
+
+/// Used to create a [`PermanentStorageReader`] and [`PermanentStorageWriter`]
+#[derive(Default, Clone, Debug)]
+pub struct PermanentStorageProvider {
+    path: PathBuf,
+    force_restart: bool,
+}
+
+///
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Not a valid path, path may not end in .progress
+    #[error("Not a valid path, path may not end in .progress")]
+    InvalidPath,
+}
+
+impl PermanentStorageProvider {
+    /// Creates a new [`PermanentStorageProvider`] to download to a user specified path. It removes any existing file throwing away any
+    /// download progress made.
+    pub fn restart(path: PathBuf) -> Result<Self, Error> {
+        Self::new(path, true)
+    }
+    /// Creates a new [`PermanentStorageProvider`] to download to a user specified path. It tries to continue if any file existed. If it can not it starts downloading from scratch overwriting existing data.
+    pub fn start(path: PathBuf) -> Result<Self, Error> {
+        Self::new(path, false)
+    }
+
+    fn new(path: PathBuf, force_restart: bool) -> Result<Self, Error> {
+        if path.extension() == Some(OsStr::new("progress")) {
+            return Err(Error::InvalidPath);
+        }
+        Ok(Self {
+            path,
+            force_restart,
+        })
+    }
+
+    fn setup_files(
+        &self,
+        content_length: Option<u64>,
+    ) -> io::Result<(BufReader<File>, BufWriter<File>, Progress)> {
+        let file = fs::OpenOptions::new().write(true).open(&self.path)?;
+        if let Some(content_length) = content_length {
+            /* TODO: handle error (for example disk full) <18-09-23> */
+            file.set_len(content_length).unwrap()
+        }
+
+        let writer = BufWriter::new(file);
+
+        let file = fs::OpenOptions::new()
+            .read(true)
+            .truncate(false)
+            .open(&self.path)?;
+        let reader = BufReader::new(file);
+
+        let progress = if self.force_restart {
+            Progress::restart(&self.path)
+        } else {
+            Progress::start_or_continue(&self.path)
+        };
+
+        Ok((reader, writer, progress))
+    }
+}
+
+impl StorageProvider for PermanentStorageProvider {
+    type Reader = PermanentStorageReader;
+    type Writer = PermanentStorageWriter;
+
+    fn into_reader_writer(
+        self,
+        content_length: Option<u64>,
+    ) -> std::io::Result<(Self::Reader, Self::Writer)> {
+        let (reader, writer, progress) = self.setup_files(content_length)?;
+        Ok((
+            PermanentStorageReader {
+                reader,
+                progress: progress.clone(),
+            },
+            PermanentStorageWriter { writer, progress },
+        ))
+    }
+}
+
+/// Reader created by a [`PermanentStorageProvider`]. Reads from a file on disk.
+pub struct PermanentStorageReader {
+    reader: BufReader<fs::File>,
+    progress: Progress,
+}
+
+impl Read for PermanentStorageReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.reader.read(buf)
+    }
+}
+
+impl Seek for PermanentStorageReader {
+    fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
+        self.reader.seek(pos)
+    }
+}
+
+/// Writer created by a [`PermanentStorageProvider`]. Writes to a file on disk.
+pub struct PermanentStorageWriter {
+    writer: BufWriter<fs::File>,
+    progress: Progress,
+}
+
+impl StorageWriter for PermanentStorageWriter {
+    fn downloaded(&self) -> Option<rangemap::RangeSet<u64>> {
+        todo!()
+    }
+}
+
+impl Write for PermanentStorageWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.writer.write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.writer.flush()
+    }
+}
+
+impl Seek for PermanentStorageWriter {
+    fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
+        self.progress.note_seek(pos);
+        self.writer.seek(pos)
+    }
+}

--- a/src/storage/permanent.rs
+++ b/src/storage/permanent.rs
@@ -32,12 +32,14 @@ pub enum Error {
 }
 
 impl PermanentStorageProvider {
-    /// Creates a new [`PermanentStorageProvider`] to download to a user specified path. It removes any existing file throwing away any
-    /// download progress made.
+    /// Creates a new [`PermanentStorageProvider`] to download to a user specified path. It removes
+    /// any existing file throwing away any download progress made.
     pub fn restart(path: PathBuf) -> Result<Self, Error> {
         Self::new(path, true)
     }
-    /// Creates a new [`PermanentStorageProvider`] to download to a user specified path. It tries to continue if any file existed. If it can not it starts downloading from scratch overwriting existing data.
+    /// Creates a new [`PermanentStorageProvider`] to download to a user specified path. It tries to
+    /// continue if any file existed. If it can not it starts downloading from scratch overwriting
+    /// existing data.
     pub fn start(path: PathBuf) -> Result<Self, Error> {
         Self::new(path, false)
     }

--- a/src/storage/permanent/progress.rs
+++ b/src/storage/permanent/progress.rs
@@ -53,12 +53,12 @@ impl Progress {
     }
 
     fn new(file_path: &Path, restart: bool) -> io::Result<Progress> {
-        let mut file = OpenOptions::new()
+        let file = OpenOptions::new()
             .read(true)
             .write(true)
             .truncate(restart)
             .open(progress_path(file_path))?;
-        remove_incomplete_writes(&mut file)?;
+
         if restart {
             todo!("init file")
         }
@@ -79,11 +79,4 @@ impl Progress {
 
 fn progress_path(file_path: &Path) -> PathBuf {
     file_path.join(".progress")
-}
-
-fn remove_incomplete_writes(file: &mut File) -> io::Result<()> {
-    let current_len = file.metadata()?.len();
-    let without_incomplete = current_len - current_len % SECTION_LENGTH as u64;
-    file.set_len(without_incomplete)?;
-    Ok(())
 }

--- a/src/storage/permanent/progress.rs
+++ b/src/storage/permanent/progress.rs
@@ -1,23 +1,89 @@
+use std::fs::{File, OpenOptions};
+use std::io::{self, Read};
+use std::mem;
+use std::ops::Range;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
+
+use rangemap::RangeSet;
 
 #[derive(Debug, Clone)]
 pub(super) struct Progress {
     inner: Arc<Mutex<Inner>>,
 }
 
+// a "serialized form" of the RangeSet that can not
+// get corrupted by partial writes if the program
+// abrubtly crashes
+//
+// format, binary: <Start of downloaded section><End of downloaded section>
+// both as u64 little endian. Therefore each section is 16 bytes long
+const SECTION_LENGTH: usize = 2 * mem::size_of::<u64>();
 #[derive(Debug)]
-struct Inner;
+struct Inner {
+    file: File,
+}
+
+impl Inner {
+    fn downloaded(&mut self) -> io::Result<RangeSet<u64>> {
+        let mut buf = Vec::new();
+        self.file.read_to_end(&mut buf)?;
+        let ranges = buf
+            .chunks_exact(SECTION_LENGTH)
+            .map(|section| section.split_at(SECTION_LENGTH / 2))
+            .map(|(a, b)| {
+                (
+                    u64::from_le_bytes(a.try_into().unwrap()),
+                    u64::from_le_bytes(b.try_into().unwrap()),
+                )
+            })
+            .map(|(start, end)| Range { start, end })
+            .collect();
+        Ok(ranges)
+    }
+}
 
 impl Progress {
-    pub(crate) fn restart(path: &std::path::PathBuf) -> Progress {
-        todo!()
+    pub(crate) fn restart(path: &Path) -> io::Result<Progress> {
+        Self::new(path, true)
     }
 
-    pub(crate) fn start_or_continue(path: &std::path::PathBuf) -> Progress {
-        todo!()
+    pub(crate) fn start_or_continue(path: &Path) -> io::Result<Progress> {
+        Self::new(path, false)
     }
 
-    pub(crate) fn note_seek(&self, pos: std::io::SeekFrom) {
+    fn new(file_path: &Path, restart: bool) -> io::Result<Progress> {
+        let mut file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .truncate(restart)
+            .open(progress_path(file_path))?;
+        remove_incomplete_writes(&mut file)?;
+        if restart {
+            todo!("init file")
+        }
+
+        Ok(Progress {
+            inner: Arc::new(Mutex::new(Inner { file })),
+        })
+    }
+
+    pub(crate) fn downloaded(&self) -> io::Result<RangeSet<u64>> {
+        self.inner.lock().unwrap().downloaded()
+    }
+
+    pub(crate) fn finish_section(&self, end: u64) -> io::Result<()> {
         todo!()
     }
+}
+
+fn progress_path(file_path: &Path) -> PathBuf {
+    file_path.join(".progress")
+}
+
+fn remove_incomplete_writes(file: &mut File) -> io::Result<()> {
+    let current_len = file.metadata()?.len();
+    let without_incomplete = current_len - current_len % SECTION_LENGTH as u64;
+    file.set_len(without_incomplete)?;
+    Ok(())
 }

--- a/src/storage/permanent/progress.rs
+++ b/src/storage/permanent/progress.rs
@@ -1,0 +1,23 @@
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug, Clone)]
+pub(super) struct Progress {
+    inner: Arc<Mutex<Inner>>,
+}
+
+#[derive(Debug)]
+struct Inner;
+
+impl Progress {
+    pub(crate) fn restart(path: &std::path::PathBuf) -> Progress {
+        todo!()
+    }
+
+    pub(crate) fn start_or_continue(path: &std::path::PathBuf) -> Progress {
+        todo!()
+    }
+
+    pub(crate) fn note_seek(&self, pos: std::io::SeekFrom) {
+        todo!()
+    }
+}

--- a/src/storage/permanent/progress.rs
+++ b/src/storage/permanent/progress.rs
@@ -72,7 +72,7 @@ impl Progress {
         self.inner.lock().unwrap().downloaded()
     }
 
-    pub(crate) fn finish_section(&self, end: u64) -> io::Result<()> {
+    pub(crate) fn finish_section(&self, _end: u64) -> io::Result<()> {
         todo!()
     }
 }

--- a/src/storage/temp.rs
+++ b/src/storage/temp.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 
 use tempfile::NamedTempFile;
 
-use super::StorageProvider;
+use super::{StorageProvider, StorageWriter};
 use crate::WrapIoResult;
 
 /// Used to create a [`TempStorageReader`] and [`File`] for writing 
@@ -33,6 +33,7 @@ impl TempStorageProvider {
     }
 }
 
+impl StorageWriter for File {}
 impl StorageProvider for TempStorageProvider {
     type Reader = TempStorageReader;
     type Writer = File;
@@ -76,3 +77,4 @@ impl Seek for TempStorageReader {
         self.reader.seek(pos)
     }
 }
+

--- a/src/storage/temp.rs
+++ b/src/storage/temp.rs
@@ -10,7 +10,8 @@ use tempfile::NamedTempFile;
 use super::StorageProvider;
 use crate::WrapIoResult;
 
-/// Creates a [`TempStorageReader`] backed by a temporary file
+/// Used to create a [`TempStorageReader`] and [`File`] for writing 
+/// backed by a temporary file
 #[derive(Default, Clone, Debug)]
 pub struct TempStorageProvider {
     storage_dir: Option<PathBuf>,

--- a/src/storage/temp.rs
+++ b/src/storage/temp.rs
@@ -10,7 +10,7 @@ use tempfile::NamedTempFile;
 use super::{StorageProvider, StorageWriter};
 use crate::WrapIoResult;
 
-/// Used to create a [`TempStorageReader`] and [`File`] for writing 
+/// Used to create a [`TempStorageReader`] and [`File`] for writing
 /// backed by a temporary file
 #[derive(Default, Clone, Debug)]
 pub struct TempStorageProvider {
@@ -77,4 +77,3 @@ impl Seek for TempStorageReader {
         self.reader.seek(pos)
     }
 }
-


### PR DESCRIPTION
This contains a start on permanent storage. It consists of a lot of refactorings in source.rs which prep that module for further work. I am not opening the PR to get the refactorings merged to prevent future merge conflicts.

As the permanent storage feature is not completed yet all the related code is kept behind the unstable-permanent-storage feature.

The refactorings:

    extract some fields to their own struct
    (downloaded, position_reachable and requested_position)
    extract handling bytes during download to its own function
    potentially controversial: remove a lot of tracing code in an attempt to help readability as these spread out the logic quite a bit (imho)
    merges prefetch and handle bytes code, this de-duplicates some of the control flow

