### PR TITLE
test: use axum as file server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,13 +42,13 @@ rodio = { version = "0.17.1", default-features = false, features = [
     "symphonia-all",
 ] }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
-tokio = { version = "1.29.1", features = ["sync", "macros", "rt-multi-thread"] }
-tower-http = { version = "0.4.3", features = ["fs"] }
-hyper = { version = "0.14.27", features = ["server"] }
+tokio = { version = "1.34.0", features = ["sync", "macros", "rt-multi-thread"] }
+tower-http = { version = "0.5.0", features = ["fs"] }
 tower = { version = "0.4.13", features = ["make"] }
 ctor = "0.2.4"
 rstest = "0.18.1"
 proptest = "1.2.0"
+axum = "0.7.1"
 
 [[example]]
 name = "basic_http"

--- a/examples/adaptive.rs
+++ b/examples/adaptive.rs
@@ -16,7 +16,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .init();
 
     let Some(url) = args().nth(1) else {
-        return Err("Usage: cargo run --example=adaptive -- <url>")?;
+        Err("Usage: cargo run --example=adaptive -- <url>")?
     };
 
     let (_stream, handle) = rodio::OutputStream::try_default()?;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.72.0"
+channel = "1.74.0"
 components = ["rustfmt", "clippy"]

--- a/src/source.rs
+++ b/src/source.rs
@@ -252,9 +252,13 @@ impl<H: StorageWriter> Source<H> {
         } else {
             debug!("file shorter than prefetch length, download finished");
             self.writer.flush()?;
-            self.downloaded
-                .write()
-                .insert(0..self.writer.stream_position()?);
+            let pos = self.writer.stream_position()?;
+
+            // prevent panicking on an empty stream
+            if pos > 0 {
+                self.downloaded.write().insert(0..pos);
+            }
+
             self.complete_download();
             Ok(PrefetchResult::EndOfFile)
         }


### PR DESCRIPTION
The latest versions of hyper don't contain a high-level server struct anymore, so we'll use axum instead.