### PR TITLE
refactor: refactor stream internals

### DIFF
--- a/src/storage/adaptive.rs
+++ b/src/storage/adaptive.rs
@@ -83,10 +83,10 @@ impl<T> Seek for AdaptiveStorageReader<T>
 where
     T: StorageReader,
 {
-    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+    fn seek(&mut self, position: SeekFrom) -> io::Result<u64> {
         match self {
-            Self::Bounded(inner) => inner.seek(pos),
-            Self::Unbounded(inner) => inner.seek(pos),
+            Self::Bounded(inner) => inner.seek(position),
+            Self::Unbounded(inner) => inner.seek(position),
         }
     }
 }
@@ -123,10 +123,10 @@ impl<T> Seek for AdaptiveStorageWriter<T>
 where
     T: StorageWriter,
 {
-    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+    fn seek(&mut self, position: SeekFrom) -> io::Result<u64> {
         match self {
-            Self::Bounded(inner) => inner.seek(pos),
-            Self::Unbounded(inner) => inner.seek(pos),
+            Self::Bounded(inner) => inner.seek(position),
+            Self::Unbounded(inner) => inner.seek(position),
         }
     }
 }

--- a/src/storage/temp.rs
+++ b/src/storage/temp.rs
@@ -71,7 +71,7 @@ impl Read for TempStorageReader {
 }
 
 impl Seek for TempStorageReader {
-    fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
-        self.reader.seek(pos)
+    fn seek(&mut self, position: io::SeekFrom) -> io::Result<u64> {
+        self.reader.seek(position)
     }
 }


### PR DESCRIPTION
Supersedes #24 

Based on refactorings from #24 

- extract some fields into their own structs
- extract some byte-handling logic into separate functions