### PR TITLE
feat: use native async traits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
   merge_group:
 
 env:
-  RUST_MIN: "1.70"
+  RUST_MIN: "1.75"
 
 jobs:
   test:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 name = "stream-download"
 version = "0.5.0"
-rust-version = "1.70.0"
+rust-version = "1.75.0"
 authors = ["Austin Schey <aschey13@gmail.com>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -13,7 +13,6 @@ keywords = ["audio", "stream", "media"]
 include = ["/src", "/examples", "/tests"]
 
 [dependencies]
-async-trait = "0.1.9"
 bytes = "1"
 futures = "0.3"
 mediatype = { version = "0.19", optional = true }

--- a/README.md
+++ b/README.md
@@ -199,4 +199,4 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
 ## Supported Rust Versions
 
-The MSRV is currently `1.70.0`.
+The MSRV is currently `1.75.0`.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.76.0"
+channel = "1.77.0"
 components = ["rustfmt", "clippy"]

--- a/src/http/reqwest_client.rs
+++ b/src/http/reqwest_client.rs
@@ -1,7 +1,6 @@
 use std::str::FromStr;
 use std::sync::OnceLock;
 
-use async_trait::async_trait;
 use bytes::Bytes;
 use futures::Stream;
 use reqwest::header::{self, AsHeaderName, HeaderMap};
@@ -60,7 +59,6 @@ impl ClientResponse for reqwest::Response {
 // per reqwest's docs, it's advisable to create a single client and reuse it
 static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
 
-#[async_trait]
 impl Client for reqwest::Client {
     type Url = reqwest::Url;
     type Response = reqwest::Response;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -7,7 +7,6 @@ use std::{fs, io};
 
 mod setup;
 
-use async_trait::async_trait;
 use bytes::Bytes;
 use futures::{Stream, StreamExt};
 use rstest::rstest;
@@ -114,7 +113,6 @@ impl TestClient {
     }
 }
 
-#[async_trait]
 impl http::Client for TestClient {
     type Url = reqwest::Url;
     type Response = TestResponse;


### PR DESCRIPTION
Now that `1.75` has been out for a while, we should remove `async_trait` in favor of Rust's native support.