### PR TITLE
feat: add method to get the stream cancellation token

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,7 +170,8 @@ impl<S> Settings<S> {
 pub struct StreamDownload<P: StorageProvider> {
     output_reader: P::Reader,
     handle: SourceHandle,
-    download_task_cancellation_token: CancellationToken,
+    /// Download task cancellation token
+    pub download_task_cancellation_token: CancellationToken,
 }
 
 impl<P: StorageProvider> StreamDownload<P> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -341,7 +341,7 @@ impl<P: StorageProvider> StreamDownload<P> {
         self.download_task_cancellation_token.cancel();
     }
 
-    /// Get a cancellation token
+    /// Get the [`CancellationToken`] for the download task.
     pub fn get_cancellation_token(&self) -> CancellationToken {
         return self.download_task_cancellation_token.clone();
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -343,7 +343,7 @@ impl<P: StorageProvider> StreamDownload<P> {
 
     /// Get the [`CancellationToken`] for the download task.
     pub fn get_cancellation_token(&self) -> CancellationToken {
-        return self.download_task_cancellation_token.clone();
+        self.download_task_cancellation_token.clone()
     }
 
     async fn from_make_stream<S, F, Fut>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,8 +170,7 @@ impl<S> Settings<S> {
 pub struct StreamDownload<P: StorageProvider> {
     output_reader: P::Reader,
     handle: SourceHandle,
-    /// Download task cancellation token
-    pub download_task_cancellation_token: CancellationToken,
+    download_task_cancellation_token: CancellationToken,
 }
 
 impl<P: StorageProvider> StreamDownload<P> {
@@ -340,6 +339,11 @@ impl<P: StorageProvider> StreamDownload<P> {
     /// This has no effect if the download is already completed.
     pub fn cancel_download(&self) {
         self.download_task_cancellation_token.cancel();
+    }
+
+    /// Get a cancellation token
+    pub fn get_cancellation_token(&self) -> CancellationToken {
+        return self.download_task_cancellation_token.clone();
     }
 
     async fn from_make_stream<S, F, Fut>(


### PR DESCRIPTION
In some cases, the stream is transferred to a different context, making it impossible to cancel from the current one. By making the download_task_cancellation_token public, you can clone the token beforehand, ensuring that cancellation remains possible regardless of the context shift