### PR TITLE
docs: fix a few problems with the examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         uses: taiki-e/install-action@cargo-nextest
       - name: Test
         run: |
-          cargo test --doc
+          cargo test --doc --all-features
           NEXTEST_TEST_THREADS=24 RUST_LOG=trace cargo llvm-cov nextest --all-features --codecov --ignore-filename-regex ".cargo|.*_test\.rs" > ./codecov.json
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -38,6 +38,11 @@ clear = true
 env = { NEXTEST_TEST_THREADS = 200 }
 install_crate = "cargo-nextest"
 
+[tasks.test-docs]
+command = "cargo"
+args = ["test", "--doc", "--all-features"]
+
+
 [tasks.open-docs]
 env = { RUSTDOCFLAGS = "--cfg docsrs -D warnings" }
 toolchain = "nightly"

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ One of `reqwest-native-tls` or `reqwest-rustls` is required if you wish to use h
 ```rust,no_run
 use std::error::Error;
 use std::io::Read;
+use std::io;
 use std::result::Result;
 
 use stream_download::storage::temp::TempStorageProvider;
@@ -52,8 +53,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
     )
     .await?;
 
-    let mut buf = Vec::new();
-    reader.read_to_end(&mut buf)?;
+    tokio::task::spawn_blocking(move || {
+        let mut buf = Vec::new();
+        reader.read_to_end(&mut buf)?;
+        Ok::<_, io::Error>(())
+    }).await??;
+    
     Ok(())
 }
 
@@ -80,6 +85,7 @@ If it's necessary to explicitly check for an infinite stream, you can check the 
 ```rust,no_run
 use std::error::Error;
 use std::io::Read;
+use std::io;
 use std::result::Result;
 
 use stream_download::http::HttpStream;
@@ -100,8 +106,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
         StreamDownload::from_stream(stream, TempStorageProvider::default(), Settings::default())
             .await?;
 
-    let mut buf = [0; 256];
-    reader.read_exact(&mut buf)?;
+    tokio::task::spawn_blocking(move || {
+        let mut buf = [0; 256];
+        reader.read_exact(&mut buf)?;
+        Ok::<_, io::Error>(())
+    }).await??;
+ 
     Ok(())
 }
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,8 +227,7 @@ impl<P: StorageProvider> StreamDownload<P> {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn Error>> {
-    ///     let mut builder = services::S3::default();
-    ///     builder
+    ///     let mut builder = services::S3::default()
     ///         .region("us-east-1")
     ///         .access_key_id("test")
     ///         .secret_access_key("test")

--- a/src/open_dal.rs
+++ b/src/open_dal.rs
@@ -14,8 +14,7 @@
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn Error>> {
-//!     let mut builder = services::S3::default();
-//!     builder
+//!     let mut builder = services::S3::default()
 //!         .region("us-east-1")
 //!         .access_key_id("test")
 //!         .secret_access_key("test")


### PR DESCRIPTION
Discovered while investigating #82 

- Doctests for extra features weren't being tested
- README examples used blocking I/O inside a Tokio task which can cause issues (especially on a single-threaded runtime)
- openDAL examples were outdated and didn't compile