### PR TITLE
feat: return specific error types when creating a stream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ reqwest = { version = "0.12.2", features = [
 ], default-features = false, optional = true }
 tap = "1.0.1"
 tempfile = { version = "3.1", optional = true }
+thiserror = "1.0.2"
 tokio = { version = "1.27", features = ["sync", "macros", "rt"] }
 tokio-util = "0.7.1"
 tracing = "0.1.36"

--- a/examples/basic_http.rs
+++ b/examples/basic_http.rs
@@ -1,5 +1,6 @@
 use std::error::Error;
 
+use stream_download::source::DecodeError;
 use stream_download::storage::temp::TempStorageProvider;
 use stream_download::{Settings, StreamDownload};
 use tracing_subscriber::EnvFilter;
@@ -12,14 +13,18 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .with_file(true)
         .init();
 
-    let reader = StreamDownload::new_http(
+    let reader = match StreamDownload::new_http(
         "http://www.hyperion-records.co.uk/audiotest/14 Clementi Piano Sonata in D major, Op 25 \
          No 6 - Movement 2 Un poco andante.MP3"
             .parse()?,
         TempStorageProvider::new(),
         Settings::default(),
     )
-    .await?;
+    .await
+    {
+        Ok(reader) => reader,
+        Err(e) => return Err(e.decode_error().await)?,
+    };
 
     tokio::task::spawn_blocking(move || {
         let (_stream, handle) = rodio::OutputStream::try_default()?;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.80.0"
+channel = "1.81.0"
 components = ["rustfmt", "clippy"]

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,2 @@
+[default]
+extend-ignore-re = ["cc5ba7d"]


### PR DESCRIPTION
This allows for getting the underlying HTTP response body if the request fails.