### PR TITLE
chore(deps): expand compatible OpenDAL version range

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ bytes = "1.6"
 educe = "0.6"
 futures = "0.3"
 mediatype = { version = "0.19", optional = true }
-opendal = { version = "0.50", optional = true }
+opendal = { version = ">=0.47,<0.51", optional = true }
 parking_lot = "0.12.1"
 pin-project-lite = { version = "0.2.9", optional = true }
 rangemap = "1"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.81.0"
+channel = "1.82.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
OpenDAL appears in the public API so it will help semver compatibility to allow all compatible versions to be used.