### PR TITLE
fix(examples): create decoder and sink on the same thread

### DIFF
--- a/examples/adaptive.rs
+++ b/examples/adaptive.rs
@@ -9,7 +9,7 @@ use stream_download::{Settings, StreamDownload};
 use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
+async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::default().add_directive("stream_download=trace".parse()?))
         .with_line_number(true)
@@ -19,9 +19,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let Some(url) = args().nth(1) else {
         Err("Usage: cargo run --example=adaptive -- <url>")?
     };
-
-    let (_stream, handle) = rodio::OutputStream::try_default()?;
-    let sink = rodio::Sink::try_new(&handle)?;
 
     let settings = Settings::default();
     let reader = match StreamDownload::new_http(
@@ -40,11 +37,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
         Ok(reader) => reader,
         Err(e) => return Err(e.decode_error().await)?,
     };
-    sink.append(rodio::Decoder::new(reader)?);
 
     let handle = tokio::task::spawn_blocking(move || {
+        let (_stream, handle) = rodio::OutputStream::try_default()?;
+        let sink = rodio::Sink::try_new(&handle)?;
+        sink.append(rodio::Decoder::new(reader)?);
         sink.sleep_until_end();
+
+        Ok::<_, Box<dyn Error + Send + Sync>>(())
     });
-    handle.await?;
+    handle.await??;
     Ok(())
 }

--- a/examples/basic_http.rs
+++ b/examples/basic_http.rs
@@ -26,14 +26,15 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         Err(e) => return Err(e.decode_error().await)?,
     };
 
-    tokio::task::spawn_blocking(move || {
+    let handle = tokio::task::spawn_blocking(move || {
         let (_stream, handle) = rodio::OutputStream::try_default()?;
         let sink = rodio::Sink::try_new(&handle)?;
         sink.append(rodio::Decoder::new(reader)?);
         sink.sleep_until_end();
+
         Ok::<_, Box<dyn Error + Send + Sync>>(())
-    })
-    .await??;
+    });
+    handle.await??;
 
     Ok(())
 }

--- a/examples/custom_client.rs
+++ b/examples/custom_client.rs
@@ -58,15 +58,12 @@ fn get_bearer_token() -> String {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
+async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::default().add_directive(LevelFilter::INFO.into()))
         .with_line_number(true)
         .with_file(true)
         .init();
-
-    let (_stream, handle) = rodio::OutputStream::try_default()?;
-    let sink = rodio::Sink::try_new(&handle)?;
 
     // Note: you may want to consider creating middleware using `reqwest-middleware` instead of a
     // custom client as shown here.
@@ -88,11 +85,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
             Ok(reader) => reader,
             Err(e) => Err(e.decode_error().await)?,
         };
-    sink.append(rodio::Decoder::new(reader)?);
 
     let handle = tokio::task::spawn_blocking(move || {
+        let (_stream, handle) = rodio::OutputStream::try_default()?;
+        let sink = rodio::Sink::try_new(&handle)?;
+        sink.append(rodio::Decoder::new(reader)?);
         sink.sleep_until_end();
+
+        Ok::<_, Box<dyn Error + Send + Sync>>(())
     });
-    handle.await?;
+    handle.await??;
     Ok(())
 }

--- a/examples/from_stream.rs
+++ b/examples/from_stream.rs
@@ -10,15 +10,13 @@ use tracing::metadata::LevelFilter;
 use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
+async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::default().add_directive(LevelFilter::INFO.into()))
         .with_line_number(true)
         .with_file(true)
         .init();
 
-    let (_stream, handle) = rodio::OutputStream::try_default()?;
-    let sink = rodio::Sink::try_new(&handle)?;
     let stream = HttpStream::<Client>::create(
         "http://www.hyperion-records.co.uk/audiotest/14 Clementi Piano Sonata in D major, Op 25 \
          No 6 - Movement 2 Un poco andante.MP3"
@@ -36,11 +34,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
             Ok(reader) => reader,
             Err(e) => return Err(e.decode_error().await)?,
         };
-    sink.append(rodio::Decoder::new(reader)?);
 
     let handle = tokio::task::spawn_blocking(move || {
+        let (_stream, handle) = rodio::OutputStream::try_default()?;
+        let sink = rodio::Sink::try_new(&handle)?;
+        sink.append(rodio::Decoder::new(reader)?);
         sink.sleep_until_end();
+
+        Ok::<_, Box<dyn Error + Send + Sync>>(())
     });
-    handle.await?;
+    handle.await??;
     Ok(())
 }

--- a/examples/infinite_stream.rs
+++ b/examples/infinite_stream.rs
@@ -15,15 +15,13 @@ use tracing_subscriber::EnvFilter;
 // See examples here: https://github.com/aschey/icy-metadata/tree/main/examples
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
+async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::default().add_directive(LevelFilter::INFO.into()))
         .with_line_number(true)
         .with_file(true)
         .init();
 
-    let (_stream, handle) = rodio::OutputStream::try_default()?;
-    let sink = rodio::Sink::try_new(&handle)?;
     let stream = HttpStream::<Client>::create(
         "https://us2.internet-radio.com/proxy/mattjohnsonradio?mp=/stream".parse()?,
     )
@@ -54,11 +52,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
         Ok(reader) => reader,
         Err(e) => Err(e.decode_error().await)?,
     };
-    sink.append(rodio::Decoder::new(reader)?);
 
     let handle = tokio::task::spawn_blocking(move || {
+        let (_stream, handle) = rodio::OutputStream::try_default()?;
+        let sink = rodio::Sink::try_new(&handle)?;
+        sink.append(rodio::Decoder::new(reader)?);
         sink.sleep_until_end();
+
+        Ok::<_, Box<dyn Error + Send + Sync>>(())
     });
-    handle.await?;
+    handle.await??;
     Ok(())
 }

--- a/examples/memory_storage.rs
+++ b/examples/memory_storage.rs
@@ -26,14 +26,15 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         Err(e) => return Err(e.decode_error().await)?,
     };
 
-    tokio::task::spawn_blocking(move || {
+    let handle = tokio::task::spawn_blocking(move || {
         let (_stream, handle) = rodio::OutputStream::try_default()?;
         let sink = rodio::Sink::try_new(&handle)?;
         sink.append(rodio::Decoder::new(reader)?);
         sink.sleep_until_end();
+
         Ok::<_, Box<dyn Error + Send + Sync>>(())
-    })
-    .await??;
+    });
+    handle.await??;
 
     Ok(())
 }

--- a/examples/s3.rs
+++ b/examples/s3.rs
@@ -71,6 +71,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         let sink = rodio::Sink::try_new(&handle)?;
         sink.append(rodio::Decoder::new(reader)?);
         sink.sleep_until_end();
+
         Ok::<_, Box<dyn Error + Send + Sync>>(())
     })
     .await??;

--- a/examples/stream_progress.rs
+++ b/examples/stream_progress.rs
@@ -71,6 +71,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         let sink = rodio::Sink::try_new(&handle)?;
         sink.append(rodio::Decoder::new(reader)?);
         sink.sleep_until_end();
+
         Ok::<_, Box<dyn Error + Send + Sync>>(())
     })
     .await??;


### PR DESCRIPTION
This seems to fix some issues with using Tokio's single-threaded runtime.