### PR TITLE
refactor!: rename get_cancellation_token to cancellation_token

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -424,8 +424,9 @@ impl<P: StorageProvider> StreamDownload<P> {
         self.download_task_cancellation_token.cancel();
     }
 
-    /// Get the [`CancellationToken`] for the download task.
-    pub fn get_cancellation_token(&self) -> CancellationToken {
+    /// Returns the [`CancellationToken`] for the download task.
+    /// This can be used to cancel the download task before it completes.
+    pub fn cancellation_token(&self) -> CancellationToken {
         self.download_task_cancellation_token.clone()
     }
 


### PR DESCRIPTION
This makes the name consistent with the other accessor methods.