### PR TITLE
refactor!: use Rust 1.80 features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
   merge_group:
 
 env:
-  RUST_MIN: "1.75"
+  RUST_MIN: "1.80"
 
 jobs:
   test:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 name = "stream-download"
 version = "0.15.1"
-rust-version = "1.75.0"
+rust-version = "1.80.0"
 authors = ["Austin Schey <aschey13@gmail.com>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -27,7 +27,6 @@ reqwest = { version = "0.12.2", features = [
   "stream",
 ], default-features = false, optional = true }
 reqwest-middleware = { version = ">=0.3,<0.5", optional = true }
-tap = "1.0.1"
 tempfile = { version = "3.1", optional = true }
 thiserror = "2.0.1"
 tokio = { version = "1.27", features = ["sync", "macros", "rt", "time"] }

--- a/README.md
+++ b/README.md
@@ -370,4 +370,4 @@ for dynamically modifying each HTTP request.
 
 ## Supported Rust Versions
 
-The MSRV is currently `1.75.0`.
+The MSRV is currently `1.80.0`.

--- a/src/source/handle.rs
+++ b/src/source/handle.rs
@@ -7,7 +7,6 @@ use std::time::Instant;
 
 use parking_lot::{Condvar, Mutex, RwLock};
 use rangemap::RangeSet;
-use tap::TapFallible;
 use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::{Notify, mpsc};
 use tracing::{debug, error};
@@ -47,7 +46,7 @@ impl SourceHandle {
     pub(crate) fn seek(&self, position: u64) {
         self.seek_tx
             .try_send(position)
-            .tap_err(|e| {
+            .inspect_err(|e| {
                 if let TrySendError::Full(capacity) = e {
                     error!("Seek buffer full. Capacity: {capacity}");
                 }

--- a/tests/proptest.rs
+++ b/tests/proptest.rs
@@ -3,7 +3,7 @@ use std::num::NonZeroUsize;
 use std::{fs, io};
 
 use proptest::prelude::*;
-use setup::{SERVER_ADDR, SERVER_RT};
+use setup::{SERVER_RT, server_addr};
 use stream_download::storage::bounded::BoundedStorageProvider;
 use stream_download::storage::memory::MemoryStorageProvider;
 use stream_download::{Settings, StreamDownload};
@@ -45,9 +45,9 @@ prop_compose! {
 proptest! {
     #[test]
     fn proptest(StreamParams { read_len, bounded_size, prefetch_bytes } in input_sizes()) {
-        let buf = SERVER_RT.get().unwrap().block_on(async move {
+        let buf = SERVER_RT.block_on(async move {
             let mut reader = StreamDownload::new_http(
-                format!("http://{}/music.mp3", SERVER_ADDR.get().unwrap())
+                format!("http://{}/music.mp3", server_addr())
                     .parse()
                     .unwrap(),
                 BoundedStorageProvider::new(MemoryStorageProvider,


### PR DESCRIPTION
Some dependencies require Rust 1.80 now: [build logs](https://github.com/aschey/stream-download-rs/actions/runs/13486065110/job/37677350024)

This also makes use of some new Rust features.