### PR TITLE
chore(deps): replace "futures" with "futures-util"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ include = ["/src", "/examples", "/tests"]
 async-trait = { version = "0.1.68", optional = true }
 bytes = "1.6"
 educe = "0.6"
-futures = "0.3"
+futures-util = "0.3"
 mediatype = { version = "0.19", optional = true }
 opendal = { version = "0.52", optional = true }
 parking_lot = "0.12.1"

--- a/src/async_read.rs
+++ b/src/async_read.rs
@@ -5,7 +5,7 @@ use std::io;
 use std::pin::Pin;
 
 use bytes::Bytes;
-use futures::Stream;
+use futures_util::Stream;
 use tokio::io::AsyncRead;
 use tokio_util::io::ReaderStream;
 

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -37,7 +37,7 @@ use std::time::Instant;
 
 use bytes::Bytes;
 use educe::Educe;
-use futures::{Future, Stream};
+use futures_util::{Future, Stream};
 use mediatype::MediaTypeBuf;
 #[cfg(feature = "reqwest")]
 pub use reqwest;
@@ -303,7 +303,7 @@ impl<C: Client> SourceStream for HttpStream<C> {
                 "attempting to seek where start is the length of the stream, returning empty \
                  stream"
             );
-            self.stream = Box::new(futures::stream::empty());
+            self.stream = Box::new(futures_util::stream::empty());
             return Ok(());
         }
 

--- a/src/http/reqwest_client.rs
+++ b/src/http/reqwest_client.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use std::sync::LazyLock;
 
 use bytes::Bytes;
-use futures::Stream;
+use futures_util::Stream;
 use reqwest::header::{self, AsHeaderName, HeaderMap};
 use tracing::warn;
 

--- a/src/open_dal.rs
+++ b/src/open_dal.rs
@@ -34,7 +34,7 @@ use std::num::NonZeroUsize;
 use std::task::Poll;
 
 use bytes::{Bytes, BytesMut};
-use futures::{Stream, ready};
+use futures_util::{Stream, ready};
 use opendal::{FuturesAsyncReader, Operator, Reader};
 use pin_project_lite::pin_project;
 use tokio_util::compat::{Compat, FuturesAsyncReadCompatExt};

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -25,7 +25,7 @@ use std::task::Poll;
 use bytes::Bytes;
 pub use command_builder::*;
 pub use ffmpeg::*;
-use futures::Stream;
+use futures_util::Stream;
 use tempfile::NamedTempFile;
 use tracing::{debug, error, warn};
 pub use yt_dlp::*;

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -10,7 +10,7 @@ use std::ops::Range;
 use std::time::{Duration, Instant};
 
 use bytes::{BufMut, Bytes, BytesMut};
-use futures::{Future, Stream, StreamExt, TryStream};
+use futures_util::{Future, Stream, StreamExt, TryStream};
 use handle::{
     DownloadStatus, Downloaded, NotifyRead, PositionReached, RequestedPosition, SourceHandle,
 };

--- a/tests/setup.rs
+++ b/tests/setup.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use axum::Router;
 use bytes::Bytes;
 use ctor::ctor;
-use futures::{Stream, StreamExt};
+use futures_util::{Stream, StreamExt};
 use stream_download::http;
 use stream_download::source::DecodeError;
 use stream_download::storage::StorageProvider;


### PR DESCRIPTION
This PR changes `stream-download` to depend on `futures-util` directly as `futures` includes (including dependencies) a lot more than is actually used in this crate.
It *might* be possible thin it down even more, but this should reduce it at least a bit already.

PS: this does not entirely drop `futures` from the workspace due to some dev-dependencies using it, but it will for consumers of `stream-download`