### PR TITLE
chore: release

### DIFF
--- a/crates/stream-download-opendal/CHANGELOG.md
+++ b/crates/stream-download-opendal/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2025-04-05
+
+### Refactor
+
+- [**breaking**] Move OpenDAL integration into separate crate ([#174](https://github.com/aschey/stream-download-rs/issues/174)) - ([987cc15](https://github.com/aschey/stream-download-rs/commit/987cc15f5307df96598d3f4d13bb04409d2b7dcf))
+

--- a/crates/stream-download-opendal/Cargo.toml
+++ b/crates/stream-download-opendal/Cargo.toml
@@ -14,7 +14,7 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-stream-download = { version = "0.17.0", path = "../stream-download", default-features = false }
+stream-download = { version = "0.18.0", path = "../stream-download", default-features = false }
 opendal = { workspace = true }
 pin-project-lite = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/stream-download/CHANGELOG.md
+++ b/crates/stream-download/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.18.0](https://github.com/aschey/stream-download-rs/compare/stream-download-v0.17.0..stream-download-v0.18.0) - 2025-04-05
+
+### Refactor
+
+- [**breaking**] Move OpenDAL integration into separate crate ([#174](https://github.com/aschey/stream-download-rs/issues/174)) - ([987cc15](https://github.com/aschey/stream-download-rs/commit/987cc15f5307df96598d3f4d13bb04409d2b7dcf))
+
 ## [0.17.0](https://github.com/aschey/stream-download-rs/compare/v0.16.1..v0.17.0) - 2025-03-31
 
 ### Refactor

--- a/crates/stream-download/CHANGELOG.md
+++ b/crates/stream-download/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 - [**breaking**] Move OpenDAL integration into separate crate ([#174](https://github.com/aschey/stream-download-rs/issues/174)) - ([987cc15](https://github.com/aschey/stream-download-rs/commit/987cc15f5307df96598d3f4d13bb04409d2b7dcf))
 
+### Dependencies
+
+- *(deps)* replace "futures" with "futures-util" ([#174](https://github.com/aschey/stream-download-rs/issues/176)) - ([3a041f5](https://github.com/aschey/stream-download-rs/commit/3a041f55e956c0d04042ec6a3e17a852cc8a3724))
+
 ## [0.17.0](https://github.com/aschey/stream-download-rs/compare/v0.16.1..v0.17.0) - 2025-03-31
 
 ### Refactor

--- a/crates/stream-download/Cargo.toml
+++ b/crates/stream-download/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stream-download"
-version = "0.17.0"
+version = "0.18.0"
 description = "A library for streaming content to a local cache"
 readme = "README.md"
 edition.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `stream-download`: 0.17.0 -> 0.18.0 (⚠ API breaking changes)
* `stream-download-opendal`: 0.1.0

### ⚠ `stream-download` breaking changes

```text
--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/feature_missing.ron

Failed in:
  feature open-dal in the package's Cargo.toml

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/inherent_method_missing.ron

Failed in:
  StreamDownload::new_open_dal, previously in file /tmp/.tmpbBNriR/stream-download/src/lib.rs:231

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/module_missing.ron

Failed in:
  mod stream_download::open_dal, previously in file /tmp/.tmpbBNriR/stream-download/src/open_dal.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/struct_missing.ron

Failed in:
  struct stream_download::open_dal::OpenDalStream, previously in file /tmp/.tmpbBNriR/stream-download/src/open_dal.rs:77
  struct stream_download::open_dal::OpenDalStreamParams, previously in file /tmp/.tmpbBNriR/stream-download/src/open_dal.rs:49
  struct stream_download::open_dal::Error, previously in file /tmp/.tmpbBNriR/stream-download/src/open_dal.rs:107
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `stream-download`

<blockquote>

## [0.18.0](https://github.com/aschey/stream-download-rs/compare/stream-download-v0.17.0..stream-download-v0.18.0) - 2025-04-05

### Refactor

- [**breaking**] Move OpenDAL integration into separate crate ([#174](https://github.com/aschey/stream-download-rs/issues/174)) - ([987cc15](https://github.com/aschey/stream-download-rs/commit/987cc15f5307df96598d3f4d13bb04409d2b7dcf))
</blockquote>

## `stream-download-opendal`

<blockquote>

## [0.1.0] - 2025-04-05

### Refactor

- [**breaking**] Move OpenDAL integration into separate crate ([#174](https://github.com/aschey/stream-download-rs/issues/174)) - ([987cc15](https://github.com/aschey/stream-download-rs/commit/987cc15f5307df96598d3f4d13bb04409d2b7dcf))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).