### PR TITLE
chore: feature flag extra dependencies in examples

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -36,7 +36,7 @@ script_runner = "@shell"
 
 [tasks.test]
 command = "cargo"
-args = ["nextest", "run", "--all-features"]
+args = ["nextest", "run"]
 clear = true
 env = { NEXTEST_TEST_THREADS = 200 }
 install_crate = "cargo-nextest"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -12,7 +12,7 @@ stream-download = { path = "../crates/stream-download", features = [
   "async-read",
   "registry",
 ] }
-stream-download-opendal = { path = "../crates/stream-download-opendal" }
+stream-download-opendal = { path = "../crates/stream-download-opendal", optional = true }
 async-trait = { workspace = true }
 tracing = { workspace = true }
 rodio = { workspace = true, default-features = false, features = [
@@ -25,7 +25,26 @@ tokio = { workspace = true, features = ["sync", "macros", "rt-multi-thread"] }
 tower = { workspace = true, features = ["make"] }
 reqwest-retry = { workspace = true }
 youtube_dl = { workspace = true, features = ["tokio"] }
-libmpv2 = { workspace = true }
-testcontainers-modules = { workspace = true, features = ["localstack"] }
-opendal = { workspace = true, features = ["services-s3"] }
-aws-sdk-s3 = { workspace = true }
+libmpv2 = { workspace = true, optional = true }
+testcontainers-modules = { workspace = true, features = [
+  "localstack",
+], optional = true }
+opendal = { workspace = true, features = ["services-s3"], optional = true }
+aws-sdk-s3 = { workspace = true, optional = true }
+
+[features]
+mpv = ["dep:libmpv2"]
+opendal = [
+  "dep:stream-download-opendal",
+  "dep:testcontainers-modules",
+  "dep:aws-sdk-s3",
+  "dep:opendal",
+]
+
+[[example]]
+name = "video_mpv"
+required-features = ["mpv"]
+
+[[example]]
+name = "s3"
+required-features = ["opendal"]


### PR DESCRIPTION
Feature flag some of the heavier dependencies that aren't used as frequently. It seems like `libmpv2` fails to build if it can't link against mpv's library, so that shouldn't be enabled by default.