### PR TITLE
chore: release

### DIFF
--- a/crates/stream-download-opendal/CHANGELOG.md
+++ b/crates/stream-download-opendal/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.2](https://github.com/aschey/stream-download-rs/compare/stream-download-opendal-v0.1.1..stream-download-opendal-v0.1.2) - 2025-04-09
+
+### Miscellaneous Tasks
+
+- Updated the following local packages: stream-download - ([0000000](https://github.com/aschey/stream-download-rs/commit/0000000))
+
 ## [0.1.1](https://github.com/aschey/stream-download-rs/compare/stream-download-opendal-v0.1.0..stream-download-opendal-v0.1.1) - 2025-04-06
 
 ### Documentation

--- a/crates/stream-download-opendal/Cargo.toml
+++ b/crates/stream-download-opendal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stream-download-opendal"
-version = "0.1.1"
+version = "0.1.2"
 readme = "README.md"
 description = "OpenDAL adapter for stream-download"
 edition.workspace = true
@@ -14,7 +14,7 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-stream-download = { version = "0.18.1", path = "../stream-download", default-features = false }
+stream-download = { version = "0.19.0", path = "../stream-download", default-features = false }
 opendal = { workspace = true }
 pin-project-lite = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/stream-download/CHANGELOG.md
+++ b/crates/stream-download/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.19.0](https://github.com/aschey/stream-download-rs/compare/stream-download-v0.18.1..stream-download-v0.19.0) - 2025-04-09
+
+### Features
+
+- Flexible bounded and unbounded storage types for adaptive provider ([#185](https://github.com/aschey/stream-download-rs/issues/185)) - ([e00c2b8](https://github.com/aschey/stream-download-rs/commit/e00c2b8c3371f9a2dacb176c2efbbbdffda291e2))
+
 ## [0.18.1](https://github.com/aschey/stream-download-rs/compare/stream-download-v0.18.0..stream-download-v0.18.1) - 2025-04-06
 
 ### Miscellaneous Tasks

--- a/crates/stream-download/CHANGELOG.md
+++ b/crates/stream-download/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-- Flexible bounded and unbounded storage types for adaptive provider ([#185](https://github.com/aschey/stream-download-rs/issues/185)) - ([e00c2b8](https://github.com/aschey/stream-download-rs/commit/e00c2b8c3371f9a2dacb176c2efbbbdffda291e2))
+-  [**breaking**] Flexible bounded and unbounded storage types for adaptive provider ([#185](https://github.com/aschey/stream-download-rs/issues/185)) - ([e00c2b8](https://github.com/aschey/stream-download-rs/commit/e00c2b8c3371f9a2dacb176c2efbbbdffda291e2))
 
 ## [0.18.1](https://github.com/aschey/stream-download-rs/compare/stream-download-v0.18.0..stream-download-v0.18.1) - 2025-04-06
 

--- a/crates/stream-download/Cargo.toml
+++ b/crates/stream-download/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stream-download"
-version = "0.18.1"
+version = "0.19.0"
 description = "A library for streaming content to a local cache"
 readme = "README.md"
 edition.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `stream-download`: 0.18.1 -> 0.19.0 (⚠ API breaking changes)
* `stream-download-opendal`: 0.1.1 -> 0.1.2

### ⚠ `stream-download` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_variant_added.ron

Failed in:
  variant AdaptiveStorageWriter:Fixed in /tmp/.tmpFnVO30/stream-download-rs/crates/stream-download/src/storage/adaptive.rs:198
  variant AdaptiveStorageWriter:Variable in /tmp/.tmpFnVO30/stream-download-rs/crates/stream-download/src/storage/adaptive.rs:200
  variant AdaptiveStorageReader:Fixed in /tmp/.tmpFnVO30/stream-download-rs/crates/stream-download/src/storage/adaptive.rs:150
  variant AdaptiveStorageReader:Variable in /tmp/.tmpFnVO30/stream-download-rs/crates/stream-download/src/storage/adaptive.rs:152

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_variant_missing.ron

Failed in:
  variant AdaptiveStorageReader::Unbounded, previously in file /tmp/.tmp9kPLmf/stream-download/src/storage/adaptive.rs:41
  variant AdaptiveStorageWriter::Unbounded, previously in file /tmp/.tmp9kPLmf/stream-download/src/storage/adaptive.rs:100

--- failure trait_requires_more_generic_type_params: trait now requires more generic type parameters ---

Description:
A trait now requires more generic type parameters than it used to. Uses of this trait that supplied the previously-required number of generic types will be broken. To fix this, consider supplying default values for newly-added generic types.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-parameter-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/trait_requires_more_generic_type_params.ron

Failed in:
  trait AdaptiveStorageReader (1 -> 2 required generic types) in /tmp/.tmpFnVO30/stream-download-rs/crates/stream-download/src/storage/adaptive.rs:142
  trait AdaptiveStorageProvider (1 -> 2 required generic types) in /tmp/.tmpFnVO30/stream-download-rs/crates/stream-download/src/storage/adaptive.rs:43
  trait AdaptiveStorageWriter (1 -> 2 required generic types) in /tmp/.tmpFnVO30/stream-download-rs/crates/stream-download/src/storage/adaptive.rs:190

--- failure type_requires_more_generic_type_params: type now requires more generic type parameters ---

Description:
A type now requires more generic type parameters than it used to. Uses of this type that supplied the previously-required number of generic types will be broken. To fix this, consider supplying default values for newly-added generic types.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-parameter-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/type_requires_more_generic_type_params.ron

Failed in:
  Enum AdaptiveStorageReader (1 -> 2 required generic types) in /tmp/.tmpFnVO30/stream-download-rs/crates/stream-download/src/storage/adaptive.rs:142
  Struct AdaptiveStorageProvider (1 -> 2 required generic types) in /tmp/.tmpFnVO30/stream-download-rs/crates/stream-download/src/storage/adaptive.rs:43
  Enum AdaptiveStorageWriter (1 -> 2 required generic types) in /tmp/.tmpFnVO30/stream-download-rs/crates/stream-download/src/storage/adaptive.rs:190
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `stream-download`

<blockquote>

## [0.19.0](https://github.com/aschey/stream-download-rs/compare/stream-download-v0.18.1..stream-download-v0.19.0) - 2025-04-09

### Features

- Flexible bounded and unbounded storage types for adaptive provider ([#185](https://github.com/aschey/stream-download-rs/issues/185)) - ([e00c2b8](https://github.com/aschey/stream-download-rs/commit/e00c2b8c3371f9a2dacb176c2efbbbdffda291e2))
</blockquote>

## `stream-download-opendal`

<blockquote>

## [0.1.2](https://github.com/aschey/stream-download-rs/compare/stream-download-opendal-v0.1.1..stream-download-opendal-v0.1.2) - 2025-04-09

### Miscellaneous Tasks

- Updated the following local packages: stream-download - ([0000000](https://github.com/aschey/stream-download-rs/commit/0000000))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).