### PR TITLE
chore: change example package name

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "examples"
+name = "stream-download-examples"
 publish = false
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
Dependabot seems to be failing because some command doesn't like that the package name is `examples`:

```
updater | 2025/04/14 01:24:19 INFO <job_997503327> Handled error whilst updating tempfile: dependency_file_not_resolvable {:message=>"error: failed to load manifest for workspace member `dependabot_tmp_dir/examples`\nreferenced by workspace at `dependabot_tmp_dir/Cargo.toml`\n\nCaused by:\n  failed to parse manifest at `dependabot_tmp_dir/examples/Cargo.toml`\n\nCaused by:\n  the binary target name `examples` is forbidden, it conflicts with cargo's build directory names"}
```