### PR TITLE
chore: release

### DIFF
--- a/crates/stream-download-opendal/CHANGELOG.md
+++ b/crates/stream-download-opendal/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.1.4](https://github.com/aschey/stream-download-rs/compare/stream-download-opendal-v0.1.3..stream-download-opendal-v0.1.4) - 2025-05-16
+## [0.2.0](https://github.com/aschey/stream-download-rs/compare/stream-download-opendal-v0.1.3..stream-download-opendal-v0.2.0) - 2025-05-16
 
 ### Miscellaneous Tasks
 

--- a/crates/stream-download-opendal/CHANGELOG.md
+++ b/crates/stream-download-opendal/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.4](https://github.com/aschey/stream-download-rs/compare/stream-download-opendal-v0.1.3..stream-download-opendal-v0.1.4) - 2025-05-16
+
+### Miscellaneous Tasks
+
+- Update Cargo.toml dependencies - ([0000000](https://github.com/aschey/stream-download-rs/commit/0000000))
+
 ## [0.1.3](https://github.com/aschey/stream-download-rs/compare/stream-download-opendal-v0.1.2..stream-download-opendal-v0.1.3) - 2025-05-04
 
 ### Miscellaneous Tasks

--- a/crates/stream-download-opendal/Cargo.toml
+++ b/crates/stream-download-opendal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stream-download-opendal"
-version = "0.1.3"
+version = "0.1.4"
 readme = "README.md"
 description = "OpenDAL adapter for stream-download"
 edition.workspace = true
@@ -14,7 +14,7 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-stream-download = { version = "0.19.1", path = "../stream-download", default-features = false }
+stream-download = { version = "0.20.0", path = "../stream-download", default-features = false }
 opendal = { workspace = true }
 pin-project-lite = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/stream-download-opendal/Cargo.toml
+++ b/crates/stream-download-opendal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stream-download-opendal"
-version = "0.1.4"
+version = "0.2.0"
 readme = "README.md"
 description = "OpenDAL adapter for stream-download"
 edition.workspace = true

--- a/crates/stream-download/CHANGELOG.md
+++ b/crates/stream-download/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.20.0](https://github.com/aschey/stream-download-rs/compare/stream-download-v0.19.1..stream-download-v0.20.0) - 2025-05-16
+
+### Miscellaneous Tasks
+
+- [**breaking**] Bump MSRV to 1.82 ([#193](https://github.com/aschey/stream-download-rs/issues/193)) - ([a9de53d](https://github.com/aschey/stream-download-rs/commit/a9de53de117521ff175dbb41b0eab64863b89dec))
+- [**breaking**] Bump MSRV to 1.85 ([#197](https://github.com/aschey/stream-download-rs/issues/197)) - ([f8c65c8](https://github.com/aschey/stream-download-rs/commit/f8c65c869663beafe787efa9dec773f7de1de2aa))
+
+### Refactor
+
+- Simplify ring buffer io::read implementation ([#195](https://github.com/aschey/stream-download-rs/issues/195)) - ([034c549](https://github.com/aschey/stream-download-rs/commit/034c5497ed8926ed03f65780dd4533ab2d73b538))
+- Apply clippy lints from Rust 1.87 ([#196](https://github.com/aschey/stream-download-rs/issues/196)) - ([f7a8e5f](https://github.com/aschey/stream-download-rs/commit/f7a8e5f5024ffbc5be6dd261268b0c21c5c44c91))
+
 ## [0.19.1](https://github.com/aschey/stream-download-rs/compare/stream-download-v0.19.0..stream-download-v0.19.1) - 2025-05-04
 
 ### Documentation

--- a/crates/stream-download/Cargo.toml
+++ b/crates/stream-download/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stream-download"
-version = "0.19.1"
+version = "0.20.0"
 description = "A library for streaming content to a local cache"
 readme = "README.md"
 edition.workspace = true


### PR DESCRIPTION


## 🤖 New release

* `stream-download`: 0.19.1 -> 0.20.0 (✓ API compatible changes)
* `stream-download-opendal`: 0.1.3 -> 0.2.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `stream-download`

<blockquote>

## [0.20.0](https://github.com/aschey/stream-download-rs/compare/stream-download-v0.19.1..stream-download-v0.20.0) - 2025-05-16

### Miscellaneous Tasks

- [**breaking**] Bump MSRV to 1.82 ([#193](https://github.com/aschey/stream-download-rs/issues/193)) - ([a9de53d](https://github.com/aschey/stream-download-rs/commit/a9de53de117521ff175dbb41b0eab64863b89dec))
- [**breaking**] Bump MSRV to 1.85 ([#197](https://github.com/aschey/stream-download-rs/issues/197)) - ([f8c65c8](https://github.com/aschey/stream-download-rs/commit/f8c65c869663beafe787efa9dec773f7de1de2aa))

### Refactor

- Simplify ring buffer io::read implementation ([#195](https://github.com/aschey/stream-download-rs/issues/195)) - ([034c549](https://github.com/aschey/stream-download-rs/commit/034c5497ed8926ed03f65780dd4533ab2d73b538))
- Apply clippy lints from Rust 1.87 ([#196](https://github.com/aschey/stream-download-rs/issues/196)) - ([f7a8e5f](https://github.com/aschey/stream-download-rs/commit/f7a8e5f5024ffbc5be6dd261268b0c21c5c44c91))
</blockquote>

## `stream-download-opendal`

<blockquote>

## [0.2.0](https://github.com/aschey/stream-download-rs/compare/stream-download-opendal-v0.1.3..stream-download-opendal-v0.2.0) - 2025-05-16

### Miscellaneous Tasks

- Update Cargo.toml dependencies - ([0000000](https://github.com/aschey/stream-download-rs/commit/0000000))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).