### PR TITLE
chore: release

### DIFF
--- a/crates/stream-download-opendal/CHANGELOG.md
+++ b/crates/stream-download-opendal/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.1](https://github.com/aschey/stream-download-rs/compare/stream-download-opendal-v0.2.0..stream-download-opendal-v0.2.1) - 2025-05-26
+
+### Miscellaneous Tasks
+
+- Updated the following local packages: stream-download - ([0000000](https://github.com/aschey/stream-download-rs/commit/0000000))
+
 ## [0.2.0](https://github.com/aschey/stream-download-rs/compare/stream-download-opendal-v0.1.3..stream-download-opendal-v0.2.0) - 2025-05-16
 
 ### Miscellaneous Tasks

--- a/crates/stream-download-opendal/CHANGELOG.md
+++ b/crates/stream-download-opendal/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.2.1](https://github.com/aschey/stream-download-rs/compare/stream-download-opendal-v0.2.0..stream-download-opendal-v0.2.1) - 2025-05-26
+## [0.3.0](https://github.com/aschey/stream-download-rs/compare/stream-download-opendal-v0.2.0..stream-download-opendal-v0.3.0) - 2025-05-26
 
 ### Miscellaneous Tasks
 

--- a/crates/stream-download-opendal/Cargo.toml
+++ b/crates/stream-download-opendal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stream-download-opendal"
-version = "0.2.1"
+version = "0.3.0"
 readme = "README.md"
 description = "OpenDAL adapter for stream-download"
 edition.workspace = true

--- a/crates/stream-download-opendal/Cargo.toml
+++ b/crates/stream-download-opendal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stream-download-opendal"
-version = "0.2.0"
+version = "0.2.1"
 readme = "README.md"
 description = "OpenDAL adapter for stream-download"
 edition.workspace = true
@@ -14,7 +14,7 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-stream-download = { version = "0.20.0", path = "../stream-download", default-features = false }
+stream-download = { version = "0.21.0", path = "../stream-download", default-features = false }
 opendal = { workspace = true }
 pin-project-lite = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/stream-download/CHANGELOG.md
+++ b/crates/stream-download/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.21.0](https://github.com/aschey/stream-download-rs/compare/stream-download-v0.20.0..stream-download-v0.21.0) - 2025-05-26
+
+### Features
+
+- Batch large writes ([#198](https://github.com/aschey/stream-download-rs/issues/198)) - ([018cd4f](https://github.com/aschey/stream-download-rs/commit/018cd4f72d5619c2cd9e504b96b95ee7ebb13d81))
+- [**breaking**] Require nonzero seek buffer size ([#200](https://github.com/aschey/stream-download-rs/issues/200)) - ([05b621c](https://github.com/aschey/stream-download-rs/commit/05b621cd7b58645a3015fa65140aa40b2f49b452))
+
 ## [0.20.0](https://github.com/aschey/stream-download-rs/compare/stream-download-v0.19.1..stream-download-v0.20.0) - 2025-05-16
 
 ### Miscellaneous Tasks

--- a/crates/stream-download/Cargo.toml
+++ b/crates/stream-download/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stream-download"
-version = "0.20.0"
+version = "0.21.0"
 description = "A library for streaming content to a local cache"
 readme = "README.md"
 edition.workspace = true


### PR DESCRIPTION


## 🤖 New release

* `stream-download`: 0.20.0 -> 0.21.0 (✓ API compatible changes)
* `stream-download-opendal`: 0.2.0 -> 0.3.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `stream-download`

<blockquote>

## [0.21.0](https://github.com/aschey/stream-download-rs/compare/stream-download-v0.20.0..stream-download-v0.21.0) - 2025-05-26

### Features

- Batch large writes ([#198](https://github.com/aschey/stream-download-rs/issues/198)) - ([018cd4f](https://github.com/aschey/stream-download-rs/commit/018cd4f72d5619c2cd9e504b96b95ee7ebb13d81))
- [**breaking**] Require nonzero seek buffer size ([#200](https://github.com/aschey/stream-download-rs/issues/200)) - ([05b621c](https://github.com/aschey/stream-download-rs/commit/05b621cd7b58645a3015fa65140aa40b2f49b452))
</blockquote>

## `stream-download-opendal`

<blockquote>

## [0.3.0](https://github.com/aschey/stream-download-rs/compare/stream-download-opendal-v0.2.0..stream-download-opendal-v0.3.0) - 2025-05-26

### Miscellaneous Tasks

- Updated the following local packages: stream-download - ([0000000](https://github.com/aschey/stream-download-rs/commit/0000000))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).