### PR TITLE
chore: release

### DIFF
--- a/crates/stream-download-opendal/CHANGELOG.md
+++ b/crates/stream-download-opendal/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.2](https://github.com/aschey/stream-download-rs/compare/stream-download-opendal-v0.3.1..stream-download-opendal-v0.3.2) - 2025-06-19
+
+### Miscellaneous Tasks
+
+- Updated the following local packages: stream-download - ([0000000](https://github.com/aschey/stream-download-rs/commit/0000000))
+
 ## [0.3.1](https://github.com/aschey/stream-download-rs/compare/stream-download-opendal-v0.3.0..stream-download-opendal-v0.3.1) - 2025-06-07
 
 ### Miscellaneous Tasks

--- a/crates/stream-download-opendal/Cargo.toml
+++ b/crates/stream-download-opendal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stream-download-opendal"
-version = "0.3.1"
+version = "0.3.2"
 readme = "README.md"
 description = "OpenDAL adapter for stream-download"
 edition.workspace = true
@@ -14,7 +14,7 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-stream-download = { version = "0.21.1", path = "../stream-download", default-features = false }
+stream-download = { version = "0.22.0", path = "../stream-download", default-features = false }
 opendal = { workspace = true }
 pin-project-lite = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/stream-download/CHANGELOG.md
+++ b/crates/stream-download/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.22.0](https://github.com/aschey/stream-download-rs/compare/stream-download-v0.21.1..stream-download-v0.22.0) - 2025-06-19
+
+### Refactor
+
+- [**breaking**] Remove seek_buffer_size ([#203](https://github.com/aschey/stream-download-rs/issues/203)) - ([66a6320](https://github.com/aschey/stream-download-rs/commit/66a6320191bca92e207a0aadd91ef05ab382f29f))
+
 ## [0.21.1](https://github.com/aschey/stream-download-rs/compare/stream-download-v0.21.0..stream-download-v0.21.1) - 2025-06-07
 
 ### Miscellaneous Tasks

--- a/crates/stream-download/Cargo.toml
+++ b/crates/stream-download/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stream-download"
-version = "0.21.1"
+version = "0.22.0"
 description = "A library for streaming content to a local cache"
 readme = "README.md"
 edition.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `stream-download`: 0.21.1 -> 0.22.0 (⚠ API breaking changes)
* `stream-download-opendal`: 0.3.1 -> 0.3.2

### ⚠ `stream-download` breaking changes

```text
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/inherent_method_missing.ron

Failed in:
  Settings::seek_buffer_size, previously in file /tmp/.tmpLH3QI2/stream-download/src/settings.rs:97
  Settings::get_seek_buffer_size, previously in file /tmp/.tmpLH3QI2/stream-download/src/settings.rs:189
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `stream-download`

<blockquote>

## [0.22.0](https://github.com/aschey/stream-download-rs/compare/stream-download-v0.21.1..stream-download-v0.22.0) - 2025-06-19

### Refactor

- [**breaking**] Remove seek_buffer_size ([#203](https://github.com/aschey/stream-download-rs/issues/203)) - ([66a6320](https://github.com/aschey/stream-download-rs/commit/66a6320191bca92e207a0aadd91ef05ab382f29f))
</blockquote>

## `stream-download-opendal`

<blockquote>

## [0.3.2](https://github.com/aschey/stream-download-rs/compare/stream-download-opendal-v0.3.1..stream-download-opendal-v0.3.2) - 2025-06-19

### Miscellaneous Tasks

- Updated the following local packages: stream-download - ([0000000](https://github.com/aschey/stream-download-rs/commit/0000000))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).