### PR TITLE
feat: prevent re-requesting previously downloaded stream portions during seek operations

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -15,7 +15,7 @@ install_crate = "cargo-nextest"
 env = { RUST_LOG = "trace", NEXTEST_TEST_THREADS = 200 }
 script = '''
 cargo llvm-cov nextest --all-features --lcov --ignore-filename-regex ".cargo|.*_test\.rs" > ./target/debug/lcov.info
-genhtml -o ./target/debug/coverage/ --show-details --highlight --ignore-errors source --legend ./target/debug/lcov.info
+genhtml -o ./target/debug/coverage/ --show-details --ignore-errors source --legend ./target/debug/lcov.info
 '''
 clear = true
 install_crate = { binary = "cargo-llvm-cov", rustup_component_name = "llvm-tools-preview" }

--- a/crates/stream-download/src/source/handle.rs
+++ b/crates/stream-download/src/source/handle.rs
@@ -164,8 +164,8 @@ impl Downloaded {
         self.0.read().get(&position).cloned()
     }
 
-    pub(super) fn next_gap(&self, range: &Range<u64>) -> Option<Range<u64>> {
-        self.0.read().gaps(range).next()
+    pub(super) fn next_gap(&self, range: Range<u64>) -> Option<Range<u64>> {
+        self.0.read().gaps(&range).next()
     }
 }
 


### PR DESCRIPTION
Prevents re-requesting the entire portion of the stream after the seek position if we've already downloaded part of it.