### PR TITLE
chore: release

### DIFF
--- a/crates/stream-download-opendal/CHANGELOG.md
+++ b/crates/stream-download-opendal/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.1](https://github.com/aschey/stream-download-rs/compare/stream-download-opendal-v0.4.0..stream-download-opendal-v0.4.1) - 2025-06-19
+
+### Miscellaneous Tasks
+
+- Updated the following local packages: stream-download - ([0000000](https://github.com/aschey/stream-download-rs/commit/0000000))
+
 ## [0.4.0](https://github.com/aschey/stream-download-rs/compare/stream-download-opendal-v0.3.1..stream-download-opendal-v0.4.0) - 2025-06-19
 
 ### Miscellaneous Tasks

--- a/crates/stream-download-opendal/Cargo.toml
+++ b/crates/stream-download-opendal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stream-download-opendal"
-version = "0.4.0"
+version = "0.4.1"
 readme = "README.md"
 description = "OpenDAL adapter for stream-download"
 edition.workspace = true
@@ -14,7 +14,7 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-stream-download = { version = "0.22.0", path = "../stream-download", default-features = false }
+stream-download = { version = "0.22.1", path = "../stream-download", default-features = false }
 opendal = { workspace = true }
 pin-project-lite = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/stream-download/CHANGELOG.md
+++ b/crates/stream-download/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.22.1](https://github.com/aschey/stream-download-rs/compare/stream-download-v0.22.0..stream-download-v0.22.1) - 2025-06-19
+
+### Features
+
+- Prevent re-requesting previously downloaded stream portions during seek operations ([#205](https://github.com/aschey/stream-download-rs/issues/205)) - ([03f645a](https://github.com/aschey/stream-download-rs/commit/03f645aea81eb5455978792b6d3eb6bb7f90074e))
+
 ## [0.22.0](https://github.com/aschey/stream-download-rs/compare/stream-download-v0.21.1..stream-download-v0.22.0) - 2025-06-19
 
 ### Refactor

--- a/crates/stream-download/Cargo.toml
+++ b/crates/stream-download/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stream-download"
-version = "0.22.0"
+version = "0.22.1"
 description = "A library for streaming content to a local cache"
 readme = "README.md"
 edition.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `stream-download`: 0.22.0 -> 0.22.1 (✓ API compatible changes)
* `stream-download-opendal`: 0.4.0 -> 0.4.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `stream-download`

<blockquote>

## [0.22.1](https://github.com/aschey/stream-download-rs/compare/stream-download-v0.22.0..stream-download-v0.22.1) - 2025-06-19

### Features

- Prevent re-requesting previously downloaded stream portions during seek operations ([#205](https://github.com/aschey/stream-download-rs/issues/205)) - ([03f645a](https://github.com/aschey/stream-download-rs/commit/03f645aea81eb5455978792b6d3eb6bb7f90074e))
</blockquote>

## `stream-download-opendal`

<blockquote>

## [0.4.1](https://github.com/aschey/stream-download-rs/compare/stream-download-opendal-v0.4.0..stream-download-opendal-v0.4.1) - 2025-06-19

### Miscellaneous Tasks

- Updated the following local packages: stream-download - ([0000000](https://github.com/aschey/stream-download-rs/commit/0000000))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).