### PR TITLE
chore: release

### DIFF
--- a/crates/stream-download-opendal/CHANGELOG.md
+++ b/crates/stream-download-opendal/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.2](https://github.com/aschey/stream-download-rs/compare/stream-download-opendal-v0.5.1..stream-download-opendal-v0.5.2) - 2025-08-24
+
+### Miscellaneous Tasks
+
+- Updated the following local packages: stream-download - ([0000000](https://github.com/aschey/stream-download-rs/commit/0000000))
+
 ## [0.5.1](https://github.com/aschey/stream-download-rs/compare/stream-download-opendal-v0.5.0..stream-download-opendal-v0.5.1) - 2025-08-19
 
 ### Miscellaneous Tasks

--- a/crates/stream-download-opendal/Cargo.toml
+++ b/crates/stream-download-opendal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stream-download-opendal"
-version = "0.5.1"
+version = "0.5.2"
 readme = "README.md"
 description = "OpenDAL adapter for stream-download"
 edition.workspace = true
@@ -14,7 +14,7 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-stream-download = { version = "0.22.3", path = "../stream-download", default-features = false }
+stream-download = { version = "0.22.4", path = "../stream-download", default-features = false }
 opendal = { workspace = true }
 pin-project-lite = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/stream-download/CHANGELOG.md
+++ b/crates/stream-download/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.22.4](https://github.com/aschey/stream-download-rs/compare/stream-download-v0.22.3..stream-download-v0.22.4) - 2025-08-24
+
+### Bug Fixes
+
+- Prevent concurrent yt-dlp downloads from conflicting with each other ([#221](https://github.com/aschey/stream-download-rs/issues/221)) - ([38f6191](https://github.com/aschey/stream-download-rs/commit/38f6191651de0f06cd1a87f47a263c4b885589d0))
+- Return error from out-of-bounds read/seek instead of hanging ([#223](https://github.com/aschey/stream-download-rs/issues/223)) - ([d44698a](https://github.com/aschey/stream-download-rs/commit/d44698a6adde2e00a3b5a6bfb760c40dba1443c8))
+
 ## [0.22.3](https://github.com/aschey/stream-download-rs/compare/stream-download-v0.22.2..stream-download-v0.22.3) - 2025-08-19
 
 ### Dependencies

--- a/crates/stream-download/Cargo.toml
+++ b/crates/stream-download/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stream-download"
-version = "0.22.3"
+version = "0.22.4"
 description = "A library for streaming content to a local cache"
 readme = "README.md"
 edition.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `stream-download`: 0.22.3 -> 0.22.4 (✓ API compatible changes)
* `stream-download-opendal`: 0.5.1 -> 0.5.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `stream-download`

<blockquote>

## [0.22.4](https://github.com/aschey/stream-download-rs/compare/stream-download-v0.22.3..stream-download-v0.22.4) - 2025-08-24

### Bug Fixes

- Prevent concurrent yt-dlp downloads from conflicting with each other ([#221](https://github.com/aschey/stream-download-rs/issues/221)) - ([38f6191](https://github.com/aschey/stream-download-rs/commit/38f6191651de0f06cd1a87f47a263c4b885589d0))
- Return error from out-of-bounds read/seek instead of hanging ([#223](https://github.com/aschey/stream-download-rs/issues/223)) - ([d44698a](https://github.com/aschey/stream-download-rs/commit/d44698a6adde2e00a3b5a6bfb760c40dba1443c8))
</blockquote>

## `stream-download-opendal`

<blockquote>

## [0.5.2](https://github.com/aschey/stream-download-rs/compare/stream-download-opendal-v0.5.1..stream-download-opendal-v0.5.2) - 2025-08-24

### Miscellaneous Tasks

- Updated the following local packages: stream-download - ([0000000](https://github.com/aschey/stream-download-rs/commit/0000000))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).