### PR TITLE
chore: fix test setup to avoid use of ctor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ aws-sdk-s3 = "1.82.0"
 axum = "0.8.3"
 proptest = "1.6.0"
 tower-http = "0.6.2"
-ctor = "0.5.0"
 
 [workspace.lints.rustdoc]
 broken_intra_doc_links = "deny"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -26,6 +26,5 @@ regex = { workspace = true }
 bytes = { workspace = true }
 tower-http = { workspace = true, features = ["fs"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
-ctor = { workspace = true }
 futures-util = { workspace = true }
 thiserror = { workspace = true }


### PR DESCRIPTION
Code used in `ctor` shouldn't rely on the Rust standard library