### PR TITLE
chore: release

### DIFF
--- a/crates/stream-download-opendal/CHANGELOG.md
+++ b/crates/stream-download-opendal/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.8.1](https://github.com/aschey/stream-download-rs/compare/stream-download-opendal-v0.8.0..stream-download-opendal-v0.8.1) - 2026-05-02
+
+### Miscellaneous Tasks
+
+- Update Cargo.toml dependencies - ([0000000](https://github.com/aschey/stream-download-rs/commit/0000000))
+
+
 ## [0.8.0](https://github.com/aschey/stream-download-rs/compare/stream-download-opendal-v0.7.0..stream-download-opendal-v0.8.0) - 2026-02-17
 
 ### Miscellaneous Tasks

--- a/crates/stream-download-opendal/CHANGELOG.md
+++ b/crates/stream-download-opendal/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.8.1](https://github.com/aschey/stream-download-rs/compare/stream-download-opendal-v0.8.0..stream-download-opendal-v0.8.1) - 2026-05-02
+## [0.9.0](https://github.com/aschey/stream-download-rs/compare/stream-download-opendal-v0.8.0..stream-download-opendal-v0.9.0) - 2026-05-02
 
 ### Miscellaneous Tasks
 

--- a/crates/stream-download-opendal/Cargo.toml
+++ b/crates/stream-download-opendal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stream-download-opendal"
-version = "0.8.1"
+version = "0.9.0"
 readme = "README.md"
 description = "OpenDAL adapter for stream-download"
 edition.workspace = true

--- a/crates/stream-download-opendal/Cargo.toml
+++ b/crates/stream-download-opendal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stream-download-opendal"
-version = "0.8.0"
+version = "0.8.1"
 readme = "README.md"
 description = "OpenDAL adapter for stream-download"
 edition.workspace = true
@@ -14,7 +14,7 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-stream-download = { version = "0.24.0", path = "../stream-download", default-features = false }
+stream-download = { version = "0.24.1", path = "../stream-download", default-features = false }
 opendal = { workspace = true }
 pin-project-lite = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/stream-download/CHANGELOG.md
+++ b/crates/stream-download/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.24.1](https://github.com/aschey/stream-download-rs/compare/stream-download-v0.24.0..stream-download-v0.24.1) - 2026-05-02
+
+### Miscellaneous Tasks
+
+- Update Cargo.toml dependencies - ([0000000](https://github.com/aschey/stream-download-rs/commit/0000000))
+
+
 ## [0.24.0](https://github.com/aschey/stream-download-rs/compare/stream-download-v0.23.0..stream-download-v0.24.0) - 2026-02-17
 
 ### Features

--- a/crates/stream-download/Cargo.toml
+++ b/crates/stream-download/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stream-download"
-version = "0.24.0"
+version = "0.24.1"
 description = "A library for streaming content to a local cache"
 readme = "README.md"
 edition.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `stream-download`: 0.24.0 -> 0.24.1 (✓ API compatible changes)
* `stream-download-opendal`: 0.8.0 -> 0.9.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `stream-download`

<blockquote>

## [0.24.1](https://github.com/aschey/stream-download-rs/compare/stream-download-v0.24.0..stream-download-v0.24.1) - 2026-05-02

### Miscellaneous Tasks

- Update Cargo.toml dependencies - ([0000000](https://github.com/aschey/stream-download-rs/commit/0000000))
</blockquote>

## `stream-download-opendal`

<blockquote>

## [0.9.0](https://github.com/aschey/stream-download-rs/compare/stream-download-opendal-v0.8.0..stream-download-opendal-v0.9.0) - 2026-05-02

### Miscellaneous Tasks

- Update Cargo.toml dependencies - ([0000000](https://github.com/aschey/stream-download-rs/commit/0000000))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).