### PR TITLE
chore: release

### DIFF
--- a/crates/stream-download-opendal/CHANGELOG.md
+++ b/crates/stream-download-opendal/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.11.1](https://github.com/aschey/stream-download-rs/compare/stream-download-opendal-v0.11.0..stream-download-opendal-v0.11.1) - 2026-08-02
+
+### Miscellaneous Tasks
+
+- Updated the following local packages: stream-download - ([0000000](https://github.com/aschey/stream-download-rs/commit/0000000))
+
+
 ## [0.11.0](https://github.com/aschey/stream-download-rs/compare/stream-download-opendal-v0.10.0..stream-download-opendal-v0.11.0) - 2026-08-02
 
 ### Dependencies

--- a/crates/stream-download-opendal/CHANGELOG.md
+++ b/crates/stream-download-opendal/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.11.1](https://github.com/aschey/stream-download-rs/compare/stream-download-opendal-v0.11.0..stream-download-opendal-v0.11.1) - 2026-08-29
+
+### Miscellaneous Tasks
+
+- Updated the following local packages: stream-download - ([0000000](https://github.com/aschey/stream-download-rs/commit/0000000))
+
+
 ## [0.11.0](https://github.com/aschey/stream-download-rs/compare/stream-download-opendal-v0.10.0..stream-download-opendal-v0.11.0) - 2026-08-02
 
 ### Dependencies

--- a/crates/stream-download-opendal/Cargo.toml
+++ b/crates/stream-download-opendal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stream-download-opendal"
-version = "0.11.0"
+version = "0.11.1"
 readme = "README.md"
 description = "OpenDAL adapter for stream-download"
 edition.workspace = true
@@ -14,7 +14,7 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-stream-download = { version = "0.24.3", path = "../stream-download", default-features = false }
+stream-download = { version = "0.24.4", path = "../stream-download", default-features = false }
 opendal = { workspace = true }
 pin-project-lite = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/stream-download/CHANGELOG.md
+++ b/crates/stream-download/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.24.4](https://github.com/aschey/stream-download-rs/compare/stream-download-v0.24.3..stream-download-v0.24.4) - 2026-08-02
+
+### Miscellaneous Tasks
+
+- Typo ([#282](https://github.com/aschey/stream-download-rs/issues/282)) - ([683aca0](https://github.com/aschey/stream-download-rs/commit/683aca0c88e4e2a826bb2f67fa3babfe314fcdbe))
+
+
 ## [0.24.3](https://github.com/aschey/stream-download-rs/compare/stream-download-v0.24.2..stream-download-v0.24.3) - 2026-08-02
 
 ### Dependencies

--- a/crates/stream-download/CHANGELOG.md
+++ b/crates/stream-download/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.24.4](https://github.com/aschey/stream-download-rs/compare/stream-download-v0.24.3..stream-download-v0.24.4) - 2026-08-29
+
+### Miscellaneous Tasks
+
+- Typo ([#282](https://github.com/aschey/stream-download-rs/issues/282)) - ([683aca0](https://github.com/aschey/stream-download-rs/commit/683aca0c88e4e2a826bb2f67fa3babfe314fcdbe))
+- Bump rust-toolchain from 1.97.1 to 1.98.0 ([#285](https://github.com/aschey/stream-download-rs/issues/285)) - ([89e00fa](https://github.com/aschey/stream-download-rs/commit/89e00fa8166c078e745536b838522a9db2f25e31))
+
+
 ## [0.24.3](https://github.com/aschey/stream-download-rs/compare/stream-download-v0.24.2..stream-download-v0.24.3) - 2026-08-02
 
 ### Dependencies

--- a/crates/stream-download/Cargo.toml
+++ b/crates/stream-download/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stream-download"
-version = "0.24.3"
+version = "0.24.4"
 description = "A library for streaming content to a local cache"
 readme = "README.md"
 edition.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `stream-download`: 0.24.3 -> 0.24.4 (✓ API compatible changes)
* `stream-download-opendal`: 0.11.0 -> 0.11.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `stream-download`

<blockquote>

## [0.24.4](https://github.com/aschey/stream-download-rs/compare/stream-download-v0.24.3..stream-download-v0.24.4) - 2026-08-29

### Miscellaneous Tasks

- Typo ([#282](https://github.com/aschey/stream-download-rs/issues/282)) - ([683aca0](https://github.com/aschey/stream-download-rs/commit/683aca0c88e4e2a826bb2f67fa3babfe314fcdbe))
- Bump rust-toolchain from 1.97.1 to 1.98.0 ([#285](https://github.com/aschey/stream-download-rs/issues/285)) - ([89e00fa](https://github.com/aschey/stream-download-rs/commit/89e00fa8166c078e745536b838522a9db2f25e31))
</blockquote>

## `stream-download-opendal`

<blockquote>

## [0.11.1](https://github.com/aschey/stream-download-rs/compare/stream-download-opendal-v0.11.0..stream-download-opendal-v0.11.1) - 2026-08-29

### Miscellaneous Tasks

- Updated the following local packages: stream-download - ([0000000](https://github.com/aschey/stream-download-rs/commit/0000000))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).